### PR TITLE
[Feat] Delivery 도메인 생성

### DIFF
--- a/src/main/java/com/followMe/delivery_server/DeliveryServerApplication.java
+++ b/src/main/java/com/followMe/delivery_server/DeliveryServerApplication.java
@@ -2,8 +2,10 @@ package com.followMe.delivery_server;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
 @SpringBootApplication
+@EnableJpaAuditing
 public class DeliveryServerApplication {
 
   public static void main(String[] args) {

--- a/src/main/java/com/followMe/delivery_server/delivery/domain/Delivery.java
+++ b/src/main/java/com/followMe/delivery_server/delivery/domain/Delivery.java
@@ -1,0 +1,70 @@
+package com.followMe.delivery_server.delivery.domain;
+
+import com.followMe.common.entity.BaseAudit;
+import com.followMe.delivery_server.delivery.domain.enums.DeliveryStatus;
+import com.followMe.delivery_server.delivery.exception.DeliveryException.InvalidDeliveryStatusException;
+import jakarta.persistence.*;
+import java.util.UUID;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "p_delivery")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Delivery extends BaseAudit {
+
+  @Id
+  @GeneratedValue(strategy = GenerationType.UUID)
+  @Column(columnDefinition = "uuid")
+  private UUID id;
+
+  @Embedded
+  private OrderId orderId;
+
+  @Enumerated(EnumType.STRING)
+  @Column(nullable = false, length = 30)
+  private DeliveryStatus status;
+
+  private Delivery(OrderId orderId) {
+    this.orderId = orderId;
+    this.status = DeliveryStatus.READY;
+  }
+
+  public static Delivery create(UUID orderId) {
+    return new Delivery(OrderId.of(orderId));
+  }
+
+  public void start() {
+    if (this.status.isTransitionNotAllowed(DeliveryStatus.IN_PROGRESS)) {
+      throw new InvalidDeliveryStatusException();
+    }
+    this.status = DeliveryStatus.IN_PROGRESS;
+  }
+
+  public void complete() {
+    if (this.status.isTransitionNotAllowed(DeliveryStatus.COMPLETED)) {
+      throw new InvalidDeliveryStatusException();
+    }
+    this.status = DeliveryStatus.COMPLETED;
+  }
+
+  public void fail() {
+    if (this.status.isTransitionNotAllowed(DeliveryStatus.FAILED)) {
+      throw new InvalidDeliveryStatusException();
+    }
+    this.status = DeliveryStatus.FAILED;
+  }
+
+  public void cancel() {
+    if (this.status.isTransitionNotAllowed(DeliveryStatus.CANCELLED)) {
+      throw new InvalidDeliveryStatusException();
+    }
+    this.status = DeliveryStatus.CANCELLED;
+  }
+
+  public void softDelete(UUID deletedBy) {
+    super.softDelete(deletedBy.toString());
+  }
+}

--- a/src/main/java/com/followMe/delivery_server/delivery/domain/Delivery.java
+++ b/src/main/java/com/followMe/delivery_server/delivery/domain/Delivery.java
@@ -20,8 +20,7 @@ public class Delivery extends BaseAudit {
   @Column(columnDefinition = "uuid")
   private UUID id;
 
-  @Embedded
-  private OrderId orderId;
+  @Embedded private OrderId orderId;
 
   @Enumerated(EnumType.STRING)
   @Column(nullable = false, length = 30)

--- a/src/main/java/com/followMe/delivery_server/delivery/domain/OrderId.java
+++ b/src/main/java/com/followMe/delivery_server/delivery/domain/OrderId.java
@@ -1,0 +1,23 @@
+package com.followMe.delivery_server.delivery.domain;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Embeddable;
+import java.util.UUID;
+import lombok.Getter;
+
+@Getter
+@Embeddable
+public class OrderId {
+  @Column(nullable = false, columnDefinition = "uuid")
+  private UUID value;
+
+  private OrderId(UUID value) {
+    this.value = value;
+  }
+
+  public OrderId() {}
+
+  public static OrderId of(UUID value) {
+    return new OrderId(value);
+  }
+}

--- a/src/main/java/com/followMe/delivery_server/delivery/domain/enums/DeliveryStatus.java
+++ b/src/main/java/com/followMe/delivery_server/delivery/domain/enums/DeliveryStatus.java
@@ -1,0 +1,29 @@
+package com.followMe.delivery_server.delivery.domain.enums;
+
+import java.util.Set;
+
+public enum DeliveryStatus {
+  READY,
+  IN_PROGRESS,
+  COMPLETED,
+  FAILED,
+  CANCELLED;
+
+  private Set<DeliveryStatus> allowedTransitions;
+
+  static {
+    READY.allowedTransitions = Set.of(IN_PROGRESS, CANCELLED);
+    IN_PROGRESS.allowedTransitions = Set.of(COMPLETED, FAILED);
+    COMPLETED.allowedTransitions = Set.of();
+    FAILED.allowedTransitions = Set.of();
+    CANCELLED.allowedTransitions = Set.of();
+  }
+
+  public boolean isTransitionNotAllowed(DeliveryStatus next) {
+    return !allowedTransitions.contains(next);
+  }
+
+  public boolean fixed() {
+    return allowedTransitions.isEmpty();
+  }
+}

--- a/src/main/java/com/followMe/delivery_server/delivery/domain/enums/DeliveryStatus.java
+++ b/src/main/java/com/followMe/delivery_server/delivery/domain/enums/DeliveryStatus.java
@@ -22,8 +22,4 @@ public enum DeliveryStatus {
   public boolean isTransitionNotAllowed(DeliveryStatus next) {
     return !allowedTransitions.contains(next);
   }
-
-  public boolean fixed() {
-    return allowedTransitions.isEmpty();
-  }
 }

--- a/src/main/java/com/followMe/delivery_server/delivery/exception/DeliveryErrorCode.java
+++ b/src/main/java/com/followMe/delivery_server/delivery/exception/DeliveryErrorCode.java
@@ -1,0 +1,32 @@
+package com.followMe.delivery_server.delivery.exception;
+
+import com.followMe.common.exception.ErrorCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@RequiredArgsConstructor
+public enum DeliveryErrorCode implements ErrorCode {
+  DELIVERY_NOT_FOUND("D001", "배달을 찾을 수 없습니다.", HttpStatus.NOT_FOUND),
+  DELIVERY_ALREADY_COMPLETED("D002", "이미 완료된 배달입니다.", HttpStatus.CONFLICT),
+  INVALID_DELIVERY_STATUS("D003", "배달 상태가 올바르지 않습니다.", HttpStatus.BAD_REQUEST),
+  ;
+
+  private final String code;
+  private final String message;
+  private final HttpStatus httpStatus;
+
+  @Override
+  public String getCode() {
+    return code;
+  }
+
+  @Override
+  public String getMessage() {
+    return message;
+  }
+
+  @Override
+  public HttpStatus getHttpStatus() {
+    return httpStatus;
+  }
+}

--- a/src/main/java/com/followMe/delivery_server/delivery/exception/DeliveryException.java
+++ b/src/main/java/com/followMe/delivery_server/delivery/exception/DeliveryException.java
@@ -1,0 +1,24 @@
+package com.followMe.delivery_server.delivery.exception;
+
+import com.followMe.common.exception.BusinessException;
+
+public class DeliveryException {
+
+  public static class DeliveryNotFoundException extends BusinessException {
+    public DeliveryNotFoundException() {
+      super(DeliveryErrorCode.DELIVERY_NOT_FOUND);
+    }
+  }
+
+  public static class DeliveryAlreadyCompletedException extends BusinessException {
+    public DeliveryAlreadyCompletedException() {
+      super(DeliveryErrorCode.DELIVERY_ALREADY_COMPLETED);
+    }
+  }
+
+  public static class InvalidDeliveryStatusException extends BusinessException {
+    public InvalidDeliveryStatusException() {
+      super(DeliveryErrorCode.INVALID_DELIVERY_STATUS);
+    }
+  }
+}

--- a/src/main/java/com/followMe/delivery_server/delivery/repository/DeliveryRepository.java
+++ b/src/main/java/com/followMe/delivery_server/delivery/repository/DeliveryRepository.java
@@ -1,0 +1,9 @@
+package com.followMe.delivery_server.delivery.repository;
+
+import com.followMe.delivery_server.delivery.domain.Delivery;
+import java.util.UUID;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface DeliveryRepository extends JpaRepository<Delivery, UUID> {}


### PR DESCRIPTION
### 📌 관련 이슈
- close #3 

### 💡 작업 내용
- Delivery 엔티티 생성 (UUID PK, OrderId VO, DeliveryStatus)                                                                                                                                                                     
- DeliveryStatus Enum 작성 및 상태 머신 구현 (READY → IN_PROGRESS → COMPLETED/FAILED, CANCELLED)                                                                                                                                 
- DeliveryRepository 작성                                                                                                                                                                                                        
- OrderId Value Object 생성 (@Embeddable)                                                                                                                                                                                        
- DeliveryErrorCode, DeliveryException 작성  

### 🔍 변경 이유
 - Delivery 도메인 기반 작업을 위한 엔티티 및 핵심 도메인 모델 구성
 - 
### 📝 리뷰 포인트 (선택)
- DeliveryStatus 상태 전이 규칙 (allowedTransitions)

### 🧠 기타 참고 사항
- ddl-auto는 현재 create로 설정되어 있음 (로컬 개발용, 추후 validate로 변경 예정)                                                                                                                                                