### PR TITLE
[FEAT] 배송 생성 기능 

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -56,6 +56,7 @@ dependencies {
 
 	implementation 'org.springframework.cloud:spring-cloud-starter-netflix-eureka-client'
 	implementation 'org.springframework.cloud:spring-cloud-starter-openfeign'
+	implementation 'org.springframework.cloud:spring-cloud-starter-circuitbreaker-resilience4j'
 	implementation 'org.springframework.cloud:spring-cloud-starter-config'
 	implementation 'org.springframework.cloud:spring-cloud-starter-bootstrap'
 

--- a/build.gradle
+++ b/build.gradle
@@ -55,6 +55,7 @@ dependencies {
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 
 	implementation 'org.springframework.cloud:spring-cloud-starter-netflix-eureka-client'
+	implementation 'org.springframework.cloud:spring-cloud-starter-openfeign'
 	implementation 'org.springframework.cloud:spring-cloud-starter-config'
 	implementation 'org.springframework.cloud:spring-cloud-starter-bootstrap'
 

--- a/src/main/java/com/followMe/delivery_server/DeliveryServerApplication.java
+++ b/src/main/java/com/followMe/delivery_server/DeliveryServerApplication.java
@@ -2,10 +2,12 @@ package com.followMe.delivery_server;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.cloud.openfeign.EnableFeignClients;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
 @SpringBootApplication
 @EnableJpaAuditing
+@EnableFeignClients
 public class DeliveryServerApplication {
 
   public static void main(String[] args) {

--- a/src/main/java/com/followMe/delivery_server/client/HubClient.java
+++ b/src/main/java/com/followMe/delivery_server/client/HubClient.java
@@ -1,0 +1,13 @@
+package com.followMe.delivery_server.client;
+
+import com.followMe.delivery_server.client.dto.HubRouteResponse;
+import java.util.UUID;
+import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+
+@FeignClient(name = "hub-service")
+public interface HubClient {
+  @GetMapping("/api/hubs/route")
+  HubRouteResponse getNodes(@RequestParam UUID sourceHubId, @RequestParam UUID vendorId);
+}

--- a/src/main/java/com/followMe/delivery_server/client/HubClient.java
+++ b/src/main/java/com/followMe/delivery_server/client/HubClient.java
@@ -6,7 +6,7 @@ import org.springframework.cloud.openfeign.FeignClient;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 
-@FeignClient(name = "hub-service")
+@FeignClient(name = "hub-service", fallbackFactory = HubClientFallbackFactory.class)
 public interface HubClient {
   @GetMapping("/api/hubs/route")
   HubRouteResponse getNodes(@RequestParam UUID sourceHubId, @RequestParam UUID vendorId);

--- a/src/main/java/com/followMe/delivery_server/client/HubClientFallbackFactory.java
+++ b/src/main/java/com/followMe/delivery_server/client/HubClientFallbackFactory.java
@@ -1,0 +1,34 @@
+package com.followMe.delivery_server.client;
+
+import com.followMe.delivery_server.client.dto.HubRouteResponse;
+import com.followMe.delivery_server.delivery.exception.DeliveryException.HubClientUnavailableException;
+import com.followMe.delivery_server.delivery.exception.DeliveryException.HubRouteNotFoundException;
+import feign.FeignException;
+import java.util.UUID;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.cloud.openfeign.FallbackFactory;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+public class HubClientFallbackFactory implements FallbackFactory<HubClient> {
+
+  @Override
+  public HubClient create(Throwable cause) {
+    return new HubClient() {
+      @Override
+      public HubRouteResponse getNodes(UUID sourceHubId, UUID vendorId) {
+        log.error(
+            "Failed to get hub route for sourceHubId: {}, vendorId: {}. Cause: {}",
+            sourceHubId,
+            vendorId,
+            cause.getMessage());
+
+        if (cause instanceof FeignException.NotFound) {
+          throw new HubRouteNotFoundException();
+        }
+        throw new HubClientUnavailableException();
+      }
+    };
+  }
+}

--- a/src/main/java/com/followMe/delivery_server/client/dto/HubNodeInfo.java
+++ b/src/main/java/com/followMe/delivery_server/client/dto/HubNodeInfo.java
@@ -3,4 +3,4 @@ package com.followMe.delivery_server.client.dto;
 import com.followMe.delivery_server.delivery.domain.enums.NodeType;
 import java.util.UUID;
 
-public record HubNodeInfo(UUID id, NodeType type, String name) {}
+public record HubNodeInfo(UUID id, NodeType type, String name, int sequence) {}

--- a/src/main/java/com/followMe/delivery_server/client/dto/HubNodeInfo.java
+++ b/src/main/java/com/followMe/delivery_server/client/dto/HubNodeInfo.java
@@ -1,0 +1,6 @@
+package com.followMe.delivery_server.client.dto;
+
+import com.followMe.delivery_server.delivery.domain.enums.NodeType;
+import java.util.UUID;
+
+public record HubNodeInfo(UUID id, NodeType type, String name) {}

--- a/src/main/java/com/followMe/delivery_server/client/dto/HubRouteResponse.java
+++ b/src/main/java/com/followMe/delivery_server/client/dto/HubRouteResponse.java
@@ -1,10 +1,12 @@
 package com.followMe.delivery_server.client.dto;
 
 import com.followMe.delivery_server.delivery.domain.Node;
+import com.followMe.delivery_server.delivery.exception.DeliveryException.InvalidNodeInformationException;
 import java.util.List;
 
 public record HubRouteResponse(List<HubNodeInfo> nodes) {
   public List<Node> toDomain() {
+    if (nodes == null || nodes.size() < 2) throw new InvalidNodeInformationException();
     return nodes.stream().map(node -> Node.of(node.type(), node.id(), node.name())).toList();
   }
 }

--- a/src/main/java/com/followMe/delivery_server/client/dto/HubRouteResponse.java
+++ b/src/main/java/com/followMe/delivery_server/client/dto/HubRouteResponse.java
@@ -1,0 +1,7 @@
+package com.followMe.delivery_server.client.dto;
+
+import com.followMe.delivery_server.delivery.domain.Node;
+import java.util.List;
+
+public record HubRouteResponse(List<HubNodeInfo> nodes) {
+}

--- a/src/main/java/com/followMe/delivery_server/client/dto/HubRouteResponse.java
+++ b/src/main/java/com/followMe/delivery_server/client/dto/HubRouteResponse.java
@@ -4,4 +4,7 @@ import com.followMe.delivery_server.delivery.domain.Node;
 import java.util.List;
 
 public record HubRouteResponse(List<HubNodeInfo> nodes) {
+  public List<Node> toDomain() {
+    return nodes.stream().map(node -> Node.of(node.type(), node.id(), node.name())).toList();
+  }
 }

--- a/src/main/java/com/followMe/delivery_server/delivery/domain/Shipment.java
+++ b/src/main/java/com/followMe/delivery_server/delivery/domain/Shipment.java
@@ -4,8 +4,7 @@ import com.followMe.common.entity.BaseAudit;
 import com.followMe.delivery_server.delivery.domain.enums.NodeType;
 import com.followMe.delivery_server.delivery.domain.enums.ShipmentStatus;
 import com.followMe.delivery_server.delivery.domain.enums.ShipmentType;
-import com.followMe.delivery_server.delivery.exception.DeliveryException.InvalidShipmentStatusException;
-import com.followMe.delivery_server.delivery.exception.DeliveryException.NodeTypeMismatchException;
+import com.followMe.delivery_server.delivery.exception.DeliveryException.*;
 import jakarta.persistence.*;
 import java.time.Instant;
 import java.util.ArrayList;
@@ -85,9 +84,9 @@ public class Shipment extends BaseAudit {
   public static List<Shipment> createList(Delivery delivery, List<Node> nodes) {
     List<Shipment> shipments = new ArrayList<>();
 
-    if (nodes.getLast().getType() != NodeType.VENDOR) throw new NodeTypeMismatchException();
+    if (nodes.getLast().getType() != NodeType.VENDOR) throw new InvalidNodeInformationException();
     if (nodes.stream().limit(nodes.size() - 1).anyMatch(n -> n.getType() == NodeType.VENDOR))
-      throw new NodeTypeMismatchException();
+      throw new InvalidNodeInformationException();
 
     for (int i = 0; i < nodes.size() - 1; i++) {
       Node fromNode = nodes.get(i);

--- a/src/main/java/com/followMe/delivery_server/delivery/domain/Shipment.java
+++ b/src/main/java/com/followMe/delivery_server/delivery/domain/Shipment.java
@@ -5,7 +5,6 @@ import com.followMe.delivery_server.delivery.domain.enums.NodeType;
 import com.followMe.delivery_server.delivery.domain.enums.ShipmentStatus;
 import com.followMe.delivery_server.delivery.domain.enums.ShipmentType;
 import com.followMe.delivery_server.delivery.exception.DeliveryException.InvalidShipmentStatusException;
-import com.followMe.delivery_server.delivery.exception.DeliveryException.InvalidShipmentTypeException;
 import com.followMe.delivery_server.delivery.exception.DeliveryException.NodeTypeMismatchException;
 import jakarta.persistence.*;
 import java.time.Instant;
@@ -71,53 +70,40 @@ public class Shipment extends BaseAudit {
   private Instant arrivedAt;
   private Instant completedAt;
 
-  private Shipment(Delivery delivery, int sequence, ShipmentType type, Node fromNode, Node toNode) {
+  private Shipment(Delivery delivery, int sequence, Node fromNode, Node toNode) {
     this.delivery = delivery;
     this.sequence = sequence;
-    checkTypeAndNodes(type, fromNode, toNode);
-    this.type = type;
+    this.type = resolveType(fromNode, toNode);
     this.from = fromNode;
     this.to = toNode;
   }
 
-  private void checkTypeAndNodes(ShipmentType type, Node fromNode, Node toNode) {
-    switch (type) {
-      case HUB_TO_HUB -> {
-        if (fromNode.getType() != NodeType.HUB || toNode.getType() != NodeType.HUB) {
-          throw new NodeTypeMismatchException();
-        }
-      }
-      case HUB_TO_VENDOR -> {
-        if (fromNode.getType() != NodeType.HUB || toNode.getType() != NodeType.VENDOR) {
-          throw new NodeTypeMismatchException();
-        }
-      }
-      default -> throw new InvalidShipmentTypeException();
-    }
-  }
-
-  public static Shipment create(
-      Delivery delivery, int sequence, ShipmentType type, Node fromNode, Node toNode) {
-    return new Shipment(delivery, sequence, type, fromNode, toNode);
+  public static Shipment create(Delivery delivery, int sequence, Node fromNode, Node toNode) {
+    return new Shipment(delivery, sequence, fromNode, toNode);
   }
 
   public static List<Shipment> createList(Delivery delivery, List<Node> nodes) {
     List<Shipment> shipments = new ArrayList<>();
+
+    if (nodes.getLast().getType() != NodeType.VENDOR) throw new NodeTypeMismatchException();
+    if (nodes.stream().limit(nodes.size() - 1).anyMatch(n -> n.getType() == NodeType.VENDOR))
+      throw new NodeTypeMismatchException();
+
     for (int i = 0; i < nodes.size() - 1; i++) {
       Node fromNode = nodes.get(i);
       Node toNode = nodes.get(i + 1);
-      ShipmentType type;
-      if (fromNode.getType() == NodeType.HUB && toNode.getType() == NodeType.HUB) {
-        type = ShipmentType.HUB_TO_HUB;
-      } else if (fromNode.getType() == NodeType.HUB && toNode.getType() == NodeType.VENDOR) {
-        type = ShipmentType.HUB_TO_VENDOR;
-      } else {
-        throw new NodeTypeMismatchException();
-      }
-      Shipment shipment = new Shipment(delivery, i + 1, type, fromNode, toNode);
+      Shipment shipment = new Shipment(delivery, i + 1, fromNode, toNode);
       shipments.add(shipment);
     }
     return shipments;
+  }
+
+  private static ShipmentType resolveType(Node from, Node to) {
+    if (from.getType() == NodeType.HUB && to.getType() == NodeType.HUB)
+      return ShipmentType.HUB_TO_HUB;
+    if (from.getType() == NodeType.HUB && to.getType() == NodeType.VENDOR)
+      return ShipmentType.HUB_TO_VENDOR;
+    throw new NodeTypeMismatchException();
   }
 
   private void transitionTo(ShipmentStatus next) {

--- a/src/main/java/com/followMe/delivery_server/delivery/dto/OrderCreateCommand.java
+++ b/src/main/java/com/followMe/delivery_server/delivery/dto/OrderCreateCommand.java
@@ -1,0 +1,5 @@
+package com.followMe.delivery_server.delivery.dto;
+
+import java.util.UUID;
+
+public record OrderCreateCommand(UUID orderId, UUID sourceHubId, UUID vendorId) {}

--- a/src/main/java/com/followMe/delivery_server/delivery/exception/DeliveryErrorCode.java
+++ b/src/main/java/com/followMe/delivery_server/delivery/exception/DeliveryErrorCode.java
@@ -14,7 +14,9 @@ public enum DeliveryErrorCode implements ErrorCode {
   SHIPMENT_ALREADY_COMPLETED("D005", "이미 완료된 배송입니다.", HttpStatus.CONFLICT),
   INVALID_SHIPMENT_STATUS("D006", "배송 상태가 올바르지 않습니다.", HttpStatus.BAD_REQUEST),
   NODE_TYPE_MISMATCH("D007", "노드 타입이 올바르지 않습니다.", HttpStatus.CONFLICT),
-  INVALID_SHIPMENT_TYPE("D008", "배송 타입이 올바르지 않습니다.", HttpStatus.BAD_REQUEST);
+  INVALID_SHIPMENT_TYPE("D008", "배송 타입이 올바르지 않습니다.", HttpStatus.BAD_REQUEST),
+  INVALID_NODE_INFORMATION("D009", "노드 정보가 올바르지 않습니다.", HttpStatus.BAD_REQUEST),
+  ;
 
   private final String code;
   private final String message;

--- a/src/main/java/com/followMe/delivery_server/delivery/exception/DeliveryErrorCode.java
+++ b/src/main/java/com/followMe/delivery_server/delivery/exception/DeliveryErrorCode.java
@@ -16,6 +16,9 @@ public enum DeliveryErrorCode implements ErrorCode {
   NODE_TYPE_MISMATCH("D007", "노드 타입이 올바르지 않습니다.", HttpStatus.CONFLICT),
   INVALID_SHIPMENT_TYPE("D008", "배송 타입이 올바르지 않습니다.", HttpStatus.BAD_REQUEST),
   INVALID_NODE_INFORMATION("D009", "노드 정보가 올바르지 않습니다.", HttpStatus.BAD_REQUEST),
+
+  HUB_CLIENT_UNAVAILABLE("H001", "Hub 서비스를 일시적으로 사용할 수 없습니다.", HttpStatus.SERVICE_UNAVAILABLE),
+  HUB_ROUTE_NOT_FOUND("H002", "Hub 경로 정보를 찾을 수 없습니다.", HttpStatus.NOT_FOUND),
   ;
 
   private final String code;

--- a/src/main/java/com/followMe/delivery_server/delivery/exception/DeliveryException.java
+++ b/src/main/java/com/followMe/delivery_server/delivery/exception/DeliveryException.java
@@ -51,4 +51,10 @@ public class DeliveryException {
       super(DeliveryErrorCode.INVALID_SHIPMENT_TYPE);
     }
   }
+
+  public static class InvalidNodeInformationException extends BusinessException {
+    public InvalidNodeInformationException() {
+      super(DeliveryErrorCode.INVALID_NODE_INFORMATION);
+    }
+  }
 }

--- a/src/main/java/com/followMe/delivery_server/delivery/exception/DeliveryException.java
+++ b/src/main/java/com/followMe/delivery_server/delivery/exception/DeliveryException.java
@@ -57,4 +57,16 @@ public class DeliveryException {
       super(DeliveryErrorCode.INVALID_NODE_INFORMATION);
     }
   }
+
+  public static class HubClientUnavailableException extends BusinessException {
+    public HubClientUnavailableException() {
+      super(DeliveryErrorCode.HUB_CLIENT_UNAVAILABLE);
+    }
+  }
+
+  public static class HubRouteNotFoundException extends BusinessException {
+    public HubRouteNotFoundException() {
+      super(DeliveryErrorCode.HUB_ROUTE_NOT_FOUND);
+    }
+  }
 }

--- a/src/main/java/com/followMe/delivery_server/delivery/service/DeliveryService.java
+++ b/src/main/java/com/followMe/delivery_server/delivery/service/DeliveryService.java
@@ -1,0 +1,3 @@
+package com.followMe.delivery_server.delivery.service;
+
+public interface DeliveryService {}

--- a/src/main/java/com/followMe/delivery_server/delivery/service/DeliveryService.java
+++ b/src/main/java/com/followMe/delivery_server/delivery/service/DeliveryService.java
@@ -1,7 +1,6 @@
 package com.followMe.delivery_server.delivery.service;
 
 import com.followMe.delivery_server.delivery.dto.OrderCreateCommand;
-import org.springframework.transaction.annotation.Transactional;
 
 public interface DeliveryService {
 

--- a/src/main/java/com/followMe/delivery_server/delivery/service/DeliveryService.java
+++ b/src/main/java/com/followMe/delivery_server/delivery/service/DeliveryService.java
@@ -1,3 +1,9 @@
 package com.followMe.delivery_server.delivery.service;
 
-public interface DeliveryService {}
+import com.followMe.delivery_server.delivery.dto.OrderCreateCommand;
+import org.springframework.transaction.annotation.Transactional;
+
+public interface DeliveryService {
+
+  void createDelivery(OrderCreateCommand command);
+}

--- a/src/main/java/com/followMe/delivery_server/delivery/service/DeliveryServiceImpl.java
+++ b/src/main/java/com/followMe/delivery_server/delivery/service/DeliveryServiceImpl.java
@@ -1,0 +1,25 @@
+package com.followMe.delivery_server.delivery.service;
+
+import com.followMe.delivery_server.client.HubClient;
+import com.followMe.delivery_server.delivery.domain.Delivery;
+import com.followMe.delivery_server.delivery.domain.Node;
+import com.followMe.delivery_server.delivery.dto.OrderCreateCommand;
+import com.followMe.delivery_server.delivery.repository.DeliveryRepository;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class DeliveryServiceImpl implements DeliveryService {
+
+  private final DeliveryRepository deliveryRepository;
+  private final HubClient hubClient;
+
+  public void createDelivery(OrderCreateCommand command) {
+
+    List<Node> nodes = hubClient.getNodes(command.sourceHubId(), command.vendorId()).toDomain();
+    Delivery delivery = Delivery.create(command.orderId(), nodes);
+    deliveryRepository.save(delivery);
+  }
+}

--- a/src/main/java/com/followMe/delivery_server/delivery/service/DeliveryServiceImpl.java
+++ b/src/main/java/com/followMe/delivery_server/delivery/service/DeliveryServiceImpl.java
@@ -8,6 +8,7 @@ import com.followMe.delivery_server.delivery.repository.DeliveryRepository;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
@@ -16,6 +17,8 @@ public class DeliveryServiceImpl implements DeliveryService {
   private final DeliveryRepository deliveryRepository;
   private final HubClient hubClient;
 
+  @Transactional
+  @Override
   public void createDelivery(OrderCreateCommand command) {
 
     List<Node> nodes = hubClient.getNodes(command.sourceHubId(), command.vendorId()).toDomain();

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -33,6 +33,20 @@ spring:
   jooq:
     sql-dialect: POSTGRES
 
+feign:
+  circuitbreaker:
+    enabled: true
+
+resilience4j:
+  circuitbreaker:
+    instances:
+      hub-service:
+        failure-rate-threshold: 50          # 회로 차단 기준
+        minimum-number-of-calls: 5          # 최소 통계 횟수
+        sliding-window-size: 10             # 최근 호출 기준 개수
+        wait-duration-in-open-state: 10s    # 차단 후 복구 시도까지 대기 시간
+        permitted-number-of-calls-in-half-open-state: 3  # 복구 시도 시 허용되는 호출 수
+
 server:
   port: 8081
 


### PR DESCRIPTION
### 📌 관련 이슈
- close #18 
- 
### 💡 작업 내용
- OpenFeign 설정 추가 및 HubClient 구현        
- 허브 서비스 응답 DTO(HubRouteResponse) 및 도메인 변환(toDomain) 구현 
- 주문 생성 이벤트 수신을 위한 OrderCreateCommand 추가     
- 배송(Delivery) 및 배송 구간(Shipment) 생성 로직 구현 
- Shipment 경로 유효성 검증 (마지막 노드만 VENDOR 허용)  
- circuitbreaker 설정 추가  


### 🔍 변경 이유
- 주문 서비스에서 주문 생성 이벤트 수신 시 배송 및 배송 구간을 자동 생성하기 위함 
- 허브 서비스로부터 허브 경로를 조회하여 구간별 Shipment를 생성하는 흐름 구축  

### 📝 리뷰 포인트 (선택)
- 경로 구조 검증 로직 (VENDOR는 마지막 노드만 허용)   
- 외부 응답을 도메인 VO로 변환하는 책임 위치   
- 한 번으로 Shipment까지 cascade 저장        

### 🧠 기타 참고 사항
허브 서비스 응답 형식: `[HUB, HUB, ..., VENDOR]` 순서의 노드 리스트
 Kafka Consumer는 별도 이슈에서 구현 예정