### PR TITLE
[Feat] Delivery 수정, 삭제

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -61,7 +61,7 @@ dependencies {
 	implementation 'org.springframework.cloud:spring-cloud-starter-config'
 	implementation 'org.springframework.cloud:spring-cloud-starter-bootstrap'
 
-	implementation 'com.followMe:common-lib:1.0.1'
+	implementation 'com.followMe:common-lib:1.0.2'
 
 	jooqGenerator 'org.postgresql:postgresql'
 	jooqGenerator 'org.jooq:jooq:3.19.30'

--- a/docs/delivery.http
+++ b/docs/delivery.http
@@ -1,3 +1,12 @@
+### [Setup] 테스트 전 데이터 초기화
+POST http://localhost:8081/internal/test/reset
+
+> {%
+    client.test("Setup: 데이터 초기화", function() {
+        client.assert(response.status === 200, "초기화 실패: " + response.status);
+    });
+%}
+
 ### ===== 배송 목록 조회 =====
 
 ### 전체 조회 (마스터)
@@ -6,8 +15,11 @@ X-User-Id: cccccccc-0000-0000-0000-000000000001
 X-User-Role: MASTER
 
 > {%
-    var ok = response.status === 200 && response.body.success;
-    client.log("[" + (ok ? "OK" : "FAIL") + "] 전체 조회 (마스터) status=" + response.status + " body=\n" + JSON.stringify(response.body, null, 2));
+    client.log(JSON.stringify(response.body, null, 2));
+    client.test("전체 조회 (마스터)", function() {
+        client.assert(response.status === 200, "status 200 기대, 실제: " + response.status);
+        client.assert(response.body.success === true, "success=true 기대");
+    });
 %}
 
 ### 상태 필터 (마스터)
@@ -16,8 +28,11 @@ X-User-Id: cccccccc-0000-0000-0000-000000000001
 X-User-Role: MASTER
 
 > {%
-    var ok = response.status === 200 && response.body.success;
-    client.log("[" + (ok ? "OK" : "FAIL") + "] 상태 필터 (마스터) status=" + response.status + " body=\n" + JSON.stringify(response.body, null, 2));
+    client.log(JSON.stringify(response.body, null, 2));
+    client.test("상태 필터 (마스터)", function() {
+        client.assert(response.status === 200, "status 200 기대, 실제: " + response.status);
+        client.assert(response.body.success === true, "success=true 기대");
+    });
 %}
 
 ### 허브 관리자 - 담당 허브 관련 배송만 자동 필터
@@ -27,8 +42,11 @@ X-User-Role: HUB_MANAGER
 X-Hub-Id: dddddddd-0000-0000-0000-000000000001
 
 > {%
-    var ok = response.status === 200 && response.body.success;
-    client.log("[" + (ok ? "OK" : "FAIL") + "] 목록 조회 (허브 관리자) status=" + response.status + " body=\n" + JSON.stringify(response.body, null, 2));
+    client.log(JSON.stringify(response.body, null, 2));
+    client.test("목록 조회 (허브 관리자)", function() {
+        client.assert(response.status === 200, "status 200 기대, 실제: " + response.status);
+        client.assert(response.body.success === true, "success=true 기대");
+    });
 %}
 
 ### 배송 담당자 - 본인 담당 배송만 자동 필터
@@ -37,8 +55,11 @@ X-User-Id: eeeeeeee-0000-0000-0000-000000000001
 X-User-Role: DELIVERY_MANAGER
 
 > {%
-    var ok = response.status === 200 && response.body.success;
-    client.log("[" + (ok ? "OK" : "FAIL") + "] 목록 조회 (배송 담당자) status=" + response.status + " body=\n" + JSON.stringify(response.body, null, 2));
+    client.log(JSON.stringify(response.body, null, 2));
+    client.test("목록 조회 (배송 담당자)", function() {
+        client.assert(response.status === 200, "status 200 기대, 실제: " + response.status);
+        client.assert(response.body.success === true, "success=true 기대");
+    });
 %}
 
 ### 업체 담당자 - 전체 조회
@@ -48,8 +69,11 @@ X-User-Role: VENDOR
 X-Vendor-Id: dddddddd-0000-0000-0000-000000000003
 
 > {%
-    var ok = response.status === 200 && response.body.success;
-    client.log("[" + (ok ? "OK" : "FAIL") + "] 목록 조회 (업체 담당자) status=" + response.status + " body=\n" + JSON.stringify(response.body, null, 2));
+    client.log(JSON.stringify(response.body, null, 2));
+    client.test("목록 조회 (업체 담당자)", function() {
+        client.assert(response.status === 200, "status 200 기대, 실제: " + response.status);
+        client.assert(response.body.success === true, "success=true 기대");
+    });
 %}
 
 ### 정렬 - 오래된 순 (마스터)
@@ -58,8 +82,11 @@ X-User-Id: cccccccc-0000-0000-0000-000000000001
 X-User-Role: MASTER
 
 > {%
-    var ok = response.status === 200 && response.body.success;
-    client.log("[" + (ok ? "OK" : "FAIL") + "] 정렬 조회 (마스터) status=" + response.status + " body=\n" + JSON.stringify(response.body, null, 2));
+    client.log(JSON.stringify(response.body, null, 2));
+    client.test("정렬 조회 (마스터)", function() {
+        client.assert(response.status === 200, "status 200 기대, 실제: " + response.status);
+        client.assert(response.body.success === true, "success=true 기대");
+    });
 %}
 
 ### ===== 배송 단건 조회 =====
@@ -70,8 +97,11 @@ X-User-Id: cccccccc-0000-0000-0000-000000000001
 X-User-Role: MASTER
 
 > {%
-    var ok = response.status === 200 && response.body.success;
-    client.log("[" + (ok ? "OK" : "FAIL") + "] 단건 조회 (마스터) status=" + response.status + " body=\n" + JSON.stringify(response.body, null, 2));
+    client.log(JSON.stringify(response.body, null, 2));
+    client.test("단건 조회 (마스터)", function() {
+        client.assert(response.status === 200, "status 200 기대, 실제: " + response.status);
+        client.assert(response.body.success === true, "success=true 기대");
+    });
 %}
 
 ### 단건 조회 (허브 관리자)
@@ -81,8 +111,11 @@ X-User-Role: HUB_MANAGER
 X-Hub-Id: dddddddd-0000-0000-0000-000000000001
 
 > {%
-    var ok = response.status === 200 && response.body.success;
-    client.log("[" + (ok ? "OK" : "FAIL") + "] 단건 조회 (허브 관리자) status=" + response.status + " body=\n" + JSON.stringify(response.body, null, 2));
+    client.log(JSON.stringify(response.body, null, 2));
+    client.test("단건 조회 (허브 관리자)", function() {
+        client.assert(response.status === 200, "status 200 기대, 실제: " + response.status);
+        client.assert(response.body.success === true, "success=true 기대");
+    });
 %}
 
 ### 주문 ID로 조회 (마스터)
@@ -91,8 +124,11 @@ X-User-Id: cccccccc-0000-0000-0000-000000000001
 X-User-Role: MASTER
 
 > {%
-    var ok = response.status === 200 && response.body.success;
-    client.log("[" + (ok ? "OK" : "FAIL") + "] 주문ID 조회 (마스터) status=" + response.status + " body=\n" + JSON.stringify(response.body, null, 2));
+    client.log(JSON.stringify(response.body, null, 2));
+    client.test("주문ID 조회 (마스터)", function() {
+        client.assert(response.status === 200, "status 200 기대, 실제: " + response.status);
+        client.assert(response.body.success === true, "success=true 기대");
+    });
 %}
 
 ### ===== 실패 케이스 =====
@@ -101,8 +137,10 @@ X-User-Role: MASTER
 GET http://localhost:8081/api/v1/deliveries?page=0&size=10
 
 > {%
-    var ok = response.body.success === false;
-    client.log("[" + (ok ? "OK" : "FAIL") + "] 헤더 없음 status=" + response.status + " body=\n" + JSON.stringify(response.body, null, 2));
+    client.log(JSON.stringify(response.body, null, 2));
+    client.test("[실패 예상] 헤더 없음", function() {
+        client.assert(response.body.success === false, "success=false 기대");
+    });
 %}
 
 ### [실패 예상] 허브 관리자 - 관련 없는 허브로 단건 접근
@@ -112,8 +150,10 @@ X-User-Role: HUB_MANAGER
 X-Hub-Id: dddddddd-0000-0000-0000-000000000099
 
 > {%
-    var ok = response.body.success === false;
-    client.log("[" + (ok ? "OK" : "FAIL") + "] 권한 없는 허브 관리자 status=" + response.status + " body=\n" + JSON.stringify(response.body, null, 2));
+    client.log(JSON.stringify(response.body, null, 2));
+    client.test("[실패 예상] 권한 없는 허브 관리자", function() {
+        client.assert(response.body.success === false, "success=false 기대");
+    });
 %}
 
 ### [실패 예상] 배송 담당자 - 타인 배송 접근
@@ -122,8 +162,10 @@ X-User-Id: eeeeeeee-0000-0000-0000-000000000099
 X-User-Role: DELIVERY_MANAGER
 
 > {%
-    var ok = response.body.success === false;
-    client.log("[" + (ok ? "OK" : "FAIL") + "] 권한 없는 배송 담당자 status=" + response.status + " body=\n" + JSON.stringify(response.body, null, 2));
+    client.log(JSON.stringify(response.body, null, 2));
+    client.test("[실패 예상] 권한 없는 배송 담당자", function() {
+        client.assert(response.body.success === false, "success=false 기대");
+    });
 %}
 
 ### [실패 예상] 존재하지 않는 배송 ID
@@ -132,8 +174,11 @@ X-User-Id: cccccccc-0000-0000-0000-000000000001
 X-User-Role: MASTER
 
 > {%
-    var ok = response.body.success === false && response.body.error.code === "D001";
-    client.log("[" + (ok ? "OK" : "FAIL") + "] 존재하지 않는 배송 status=" + response.status + " body=\n" + JSON.stringify(response.body, null, 2));
+    client.log(JSON.stringify(response.body, null, 2));
+    client.test("[실패 예상] 존재하지 않는 배송", function() {
+        client.assert(response.body.success === false, "success=false 기대");
+        client.assert(response.body.error.code === "D001", "에러코드 D001 기대");
+    });
 %}
 
 ### [실패 예상] 존재하지 않는 주문 ID
@@ -142,8 +187,11 @@ X-User-Id: cccccccc-0000-0000-0000-000000000001
 X-User-Role: MASTER
 
 > {%
-    var ok = response.body.success === false && response.body.error.code === "D001";
-    client.log("[" + (ok ? "OK" : "FAIL") + "] 존재하지 않는 주문ID status=" + response.status + " body=\n" + JSON.stringify(response.body, null, 2));
+    client.log(JSON.stringify(response.body, null, 2));
+    client.test("[실패 예상] 존재하지 않는 주문ID", function() {
+        client.assert(response.body.success === false, "success=false 기대");
+        client.assert(response.body.error.code === "D001", "에러코드 D001 기대");
+    });
 %}
 
 ### [실패 예상] 잘못된 UUID 형식
@@ -152,8 +200,10 @@ X-User-Id: cccccccc-0000-0000-0000-000000000001
 X-User-Role: MASTER
 
 > {%
-    var ok = response.body.success === false;
-    client.log("[" + (ok ? "OK" : "FAIL") + "] 잘못된 UUID status=" + response.status + " body=\n" + JSON.stringify(response.body, null, 2));
+    client.log(JSON.stringify(response.body, null, 2));
+    client.test("[실패 예상] 잘못된 UUID", function() {
+        client.assert(response.body.success === false, "success=false 기대");
+    });
 %}
 
 ### ===== 배송 생성 =====
@@ -171,8 +221,11 @@ X-User-Role: MASTER
 }
 
 > {%
-    var ok = response.status === 200 && response.body.success;
-    client.log("[" + (ok ? "OK" : "FAIL") + "] 배송 생성 status=" + response.status + " body=\n" + JSON.stringify(response.body, null, 2));
+    client.log(JSON.stringify(response.body, null, 2));
+    client.test("배송 생성", function() {
+        client.assert(response.status === 200, "status 200 기대, 실제: " + response.status);
+        client.assert(response.body.success === true, "success=true 기대");
+    });
 %}
 
 ### [실패 예상] HubClient 연결 불가
@@ -188,6 +241,215 @@ X-User-Role: MASTER
 }
 
 > {%
-    var ok = response.body.success === false;
-    client.log("[" + (ok ? "OK" : "FAIL") + "] HubClient 연결 불가 status=" + response.status + " body=\n" + JSON.stringify(response.body, null, 2));
+    client.log(JSON.stringify(response.body, null, 2));
+    client.test("[실패 예상] HubClient 연결 불가", function() {
+        client.assert(response.body.success === false, "success=false 기대");
+    });
+%}
+
+### ===== 배송 취소 =====
+
+### [Setup] 취소 테스트 전 데이터 초기화
+POST http://localhost:8081/internal/test/reset
+
+> {%
+    client.test("Setup: 데이터 초기화", function() {
+        client.assert(response.status === 200, "초기화 실패: " + response.status);
+    });
+%}
+
+### 취소 (마스터)
+PATCH http://localhost:8081/api/v1/deliveries/aaaaaaaa-0000-0000-0000-000000000001/cancel
+X-User-Id: cccccccc-0000-0000-0000-000000000001
+X-User-Role: MASTER
+
+> {%
+    client.log(JSON.stringify(response.body, null, 2));
+    client.test("취소 (마스터)", function() {
+        client.assert(response.status === 200, "status 200 기대, 실제: " + response.status);
+        client.assert(response.body.success === true, "success=true 기대");
+    });
+%}
+
+### [Setup] 취소 (허브 관리자) 전 초기화
+POST http://localhost:8081/internal/test/reset
+
+> {%
+    client.test("Setup: 데이터 초기화", function() {
+        client.assert(response.status === 200, "초기화 실패: " + response.status);
+    });
+%}
+
+### 취소 (허브 관리자 - 관련 허브)
+PATCH http://localhost:8081/api/v1/deliveries/aaaaaaaa-0000-0000-0000-000000000001/cancel
+X-User-Id: cccccccc-0000-0000-0000-000000000002
+X-User-Role: HUB_MANAGER
+X-Hub-Id: dddddddd-0000-0000-0000-000000000001
+
+> {%
+    client.log(JSON.stringify(response.body, null, 2));
+    client.test("취소 (허브 관리자)", function() {
+        client.assert(response.status === 200, "status 200 기대, 실제: " + response.status);
+        client.assert(response.body.success === true, "success=true 기대");
+    });
+%}
+
+### [Setup] 취소 (업체 담당자) 전 초기화
+POST http://localhost:8081/internal/test/reset
+
+> {%
+    client.test("Setup: 데이터 초기화", function() {
+        client.assert(response.status === 200, "초기화 실패: " + response.status);
+    });
+%}
+
+### 취소 (업체 담당자 - 도착지 일치)
+PATCH http://localhost:8081/api/v1/deliveries/aaaaaaaa-0000-0000-0000-000000000001/cancel
+X-User-Id: cccccccc-0000-0000-0000-000000000003
+X-User-Role: VENDOR
+X-Vendor-Id: dddddddd-0000-0000-0000-000000000003
+
+> {%
+    client.log(JSON.stringify(response.body, null, 2));
+    client.test("취소 (업체 담당자)", function() {
+        client.assert(response.status === 200, "status 200 기대, 실제: " + response.status);
+        client.assert(response.body.success === true, "success=true 기대");
+    });
+%}
+
+### [실패 예상] 취소 - 허브 관리자 권한 없음 (관련 없는 허브)
+PATCH http://localhost:8081/api/v1/deliveries/aaaaaaaa-0000-0000-0000-000000000001/cancel
+X-User-Id: cccccccc-0000-0000-0000-000000000002
+X-User-Role: HUB_MANAGER
+X-Hub-Id: dddddddd-0000-0000-0000-000000000099
+
+> {%
+    client.log(JSON.stringify(response.body, null, 2));
+    client.test("[실패 예상] 취소 - 권한 없는 허브 관리자", function() {
+        client.assert(response.body.success === false, "success=false 기대");
+    });
+%}
+
+### [실패 예상] 취소 - 업체 담당자 도착지 불일치
+PATCH http://localhost:8081/api/v1/deliveries/aaaaaaaa-0000-0000-0000-000000000001/cancel
+X-User-Id: cccccccc-0000-0000-0000-000000000003
+X-User-Role: VENDOR
+X-Vendor-Id: dddddddd-0000-0000-0000-000000000099
+
+> {%
+    client.log(JSON.stringify(response.body, null, 2));
+    client.test("[실패 예상] 취소 - 도착지 불일치", function() {
+        client.assert(response.body.success === false, "success=false 기대");
+    });
+%}
+
+### [실패 예상] 취소 - 배송 담당자는 취소 불가
+PATCH http://localhost:8081/api/v1/deliveries/aaaaaaaa-0000-0000-0000-000000000001/cancel
+X-User-Id: eeeeeeee-0000-0000-0000-000000000001
+X-User-Role: DELIVERY_MANAGER
+
+> {%
+    client.log(JSON.stringify(response.body, null, 2));
+    client.test("[실패 예상] 취소 - 배송 담당자 불가", function() {
+        client.assert(response.body.success === false, "success=false 기대");
+    });
+%}
+
+### [실패 예상] 취소 - 존재하지 않는 배송
+PATCH http://localhost:8081/api/v1/deliveries/aaaaaaaa-0000-0000-0000-000000000099/cancel
+X-User-Id: cccccccc-0000-0000-0000-000000000001
+X-User-Role: MASTER
+
+> {%
+    client.log(JSON.stringify(response.body, null, 2));
+    client.test("[실패 예상] 취소 - 존재하지 않는 배송", function() {
+        client.assert(response.body.success === false, "success=false 기대");
+        client.assert(response.body.error.code === "D001", "에러코드 D001 기대");
+    });
+%}
+
+### ===== 배송 삭제 =====
+
+### [Setup] 삭제 테스트 전 데이터 초기화
+POST http://localhost:8081/internal/test/reset
+
+> {%
+    client.test("Setup: 데이터 초기화", function() {
+        client.assert(response.status === 200, "초기화 실패: " + response.status);
+    });
+%}
+
+### 삭제 (마스터)
+DELETE http://localhost:8081/api/v1/deliveries/aaaaaaaa-0000-0000-0000-000000000001
+X-User-Id: cccccccc-0000-0000-0000-000000000001
+X-User-Role: MASTER
+
+> {%
+    client.log(JSON.stringify(response.body, null, 2));
+    client.test("삭제 (마스터)", function() {
+        client.assert(response.status === 200, "status 200 기대, 실제: " + response.status);
+        client.assert(response.body.success === true, "success=true 기대");
+    });
+%}
+
+### [Setup] 삭제 (허브 관리자) 전 초기화
+POST http://localhost:8081/internal/test/reset
+
+> {%
+    client.test("Setup: 데이터 초기화", function() {
+        client.assert(response.status === 200, "초기화 실패: " + response.status);
+    });
+%}
+
+### 삭제 (허브 관리자 - 출발 허브 일치)
+DELETE http://localhost:8081/api/v1/deliveries/aaaaaaaa-0000-0000-0000-000000000001
+X-User-Id: cccccccc-0000-0000-0000-000000000002
+X-User-Role: HUB_MANAGER
+X-Hub-Id: dddddddd-0000-0000-0000-000000000001
+
+> {%
+    client.log(JSON.stringify(response.body, null, 2));
+    client.test("삭제 (허브 관리자)", function() {
+        client.assert(response.status === 200, "status 200 기대, 실제: " + response.status);
+        client.assert(response.body.success === true, "success=true 기대");
+    });
+%}
+
+### [실패 예상] 삭제 - 허브 관리자 출발 허브 불일치
+DELETE http://localhost:8081/api/v1/deliveries/aaaaaaaa-0000-0000-0000-000000000001
+X-User-Id: cccccccc-0000-0000-0000-000000000002
+X-User-Role: HUB_MANAGER
+X-Hub-Id: dddddddd-0000-0000-0000-000000000099
+
+> {%
+    client.log(JSON.stringify(response.body, null, 2));
+    client.test("[실패 예상] 삭제 - 출발 허브 불일치", function() {
+        client.assert(response.body.success === false, "success=false 기대");
+    });
+%}
+
+### [실패 예상] 삭제 - 업체 담당자는 삭제 불가
+DELETE http://localhost:8081/api/v1/deliveries/aaaaaaaa-0000-0000-0000-000000000001
+X-User-Id: cccccccc-0000-0000-0000-000000000003
+X-User-Role: VENDOR
+X-Vendor-Id: dddddddd-0000-0000-0000-000000000003
+
+> {%
+    client.log(JSON.stringify(response.body, null, 2));
+    client.test("[실패 예상] 삭제 - 업체 담당자 불가", function() {
+        client.assert(response.body.success === false, "success=false 기대");
+    });
+%}
+
+### [실패 예상] 삭제 - 존재하지 않는 배송
+DELETE http://localhost:8081/api/v1/deliveries/aaaaaaaa-0000-0000-0000-000000000099
+X-User-Id: cccccccc-0000-0000-0000-000000000001
+X-User-Role: MASTER
+
+> {%
+    client.log(JSON.stringify(response.body, null, 2));
+    client.test("[실패 예상] 삭제 - 존재하지 않는 배송", function() {
+        client.assert(response.body.success === false, "success=false 기대");
+        client.assert(response.body.error.code === "D001", "에러코드 D001 기대");
+    });
 %}

--- a/src/main/java/com/followMe/delivery_server/DeliveryServerApplication.java
+++ b/src/main/java/com/followMe/delivery_server/DeliveryServerApplication.java
@@ -2,12 +2,16 @@ package com.followMe.delivery_server;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.autoconfigure.domain.EntityScan;
 import org.springframework.cloud.openfeign.EnableFeignClients;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
 
 @SpringBootApplication
 @EnableJpaAuditing
 @EnableFeignClients
+@EnableJpaRepositories(basePackages = "com.followMe")
+@EntityScan(basePackages = "com.followMe")
 public class DeliveryServerApplication {
 
   public static void main(String[] args) {

--- a/src/main/java/com/followMe/delivery_server/config/AuditConfig.java
+++ b/src/main/java/com/followMe/delivery_server/config/AuditConfig.java
@@ -1,0 +1,34 @@
+package com.followMe.delivery_server.config;
+
+import jakarta.servlet.http.HttpServletRequest;
+import java.util.Optional;
+import java.util.UUID;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.domain.AuditorAware;
+import org.springframework.web.context.request.RequestContextHolder;
+import org.springframework.web.context.request.ServletRequestAttributes;
+
+@Configuration
+public class AuditConfig {
+
+  private static final UUID SYSTEM = UUID.fromString("00000000-0000-0000-0000-000000000000");
+
+  @Bean
+  public AuditorAware<UUID> auditorAware() {
+    return () -> {
+      var attrs = RequestContextHolder.getRequestAttributes();
+      if (attrs instanceof ServletRequestAttributes servletAttrs) {
+        HttpServletRequest request = servletAttrs.getRequest();
+        String userId = request.getHeader("X-User-Id");
+        if (userId != null) {
+          try {
+            return Optional.of(UUID.fromString(userId));
+          } catch (IllegalArgumentException ignored) {
+          }
+        }
+      }
+      return Optional.of(SYSTEM);
+    };
+  }
+}

--- a/src/main/java/com/followMe/delivery_server/delivery/application/DeliveryPermissionChecker.java
+++ b/src/main/java/com/followMe/delivery_server/delivery/application/DeliveryPermissionChecker.java
@@ -17,7 +17,25 @@ public class DeliveryPermissionChecker {
 
     checkReadAccess(user, shipmentInfoIds.nodeIds, shipmentInfoIds.managerIds);
   }
+
+  public static void checkCancelAccess(UserContext user, Delivery delivery) {
+    ShipmentInfoIds shipmentInfoIds = getShipmentInfoIds(delivery.getShipments());
+    switch (user.role()) {
+      case MASTER -> {}
+      case HUB_MANAGER -> {
+        if (user.hubId() == null || !shipmentInfoIds.nodeIds.contains(user.hubId())) {
+          throw new BusinessException(CommonErrorCode.FORBIDDEN);
+        }
+      }
+      case VENDOR -> {
+        Shipment lastShipment = delivery.getShipments().getLast();
+        if (user.vendorId() == null || !user.vendorId().equals(lastShipment.getTo().getId())) {
+          throw new BusinessException(CommonErrorCode.FORBIDDEN);
+        }
+      }
+      default -> throw new BusinessException(CommonErrorCode.FORBIDDEN);
     }
+  }
     }
   }
 

--- a/src/main/java/com/followMe/delivery_server/delivery/application/DeliveryPermissionChecker.java
+++ b/src/main/java/com/followMe/delivery_server/delivery/application/DeliveryPermissionChecker.java
@@ -6,18 +6,18 @@ import com.followMe.common.exception.BusinessException;
 import com.followMe.common.exception.CommonErrorCode;
 import com.followMe.delivery_server.delivery.application.dto.DeliveryResponseDto;
 import com.followMe.delivery_server.delivery.application.dto.DeliverySearchCondition;
-import java.util.UUID;
+import com.followMe.delivery_server.delivery.domain.Delivery;
+import com.followMe.delivery_server.delivery.domain.Shipment;
+import java.util.*;
 
 public class DeliveryPermissionChecker {
 
-  public static void checkAccess(UserContext user, DeliveryResponseDto delivery) {
-    if (user.role() == MASTER || user.role() == VENDOR) return;
-    if (user.role() == HUB_MANAGER) {
-      checkIfDeliveryRelatedToUserHub(user, delivery);
-      return;
+  public static void checkReadAccess(UserContext user, DeliveryResponseDto delivery) {
+    ShipmentInfoIds shipmentInfoIds = getShipmentInfoIds(delivery);
+
+    checkReadAccess(user, shipmentInfoIds.nodeIds, shipmentInfoIds.managerIds);
+  }
     }
-    if (user.role() == DELIVERY_MANAGER) {
-      checkIfDeliveryAssignedToUser(user, delivery);
     }
   }
 
@@ -30,30 +30,55 @@ public class DeliveryPermissionChecker {
     }
   }
 
-  private static void checkIfDeliveryAssignedToUser(
-      UserContext user, DeliveryResponseDto delivery) {
-    boolean assigned = true;
-    for (var shipment : delivery.shipments()) {
-      var deliveryManager = shipment.deliveryManager();
-      if (deliveryManager != null && !user.userId().equals(deliveryManager.id())) {
-        assigned = false;
-        break;
-      }
+  private record ShipmentInfoIds(Set<UUID> nodeIds, Set<UUID> managerIds) {}
+
+  private static ShipmentInfoIds getShipmentInfoIds(List<Shipment> shipments) {
+    Set<UUID> nodeIds = new HashSet<>();
+    Set<UUID> managerIds = new HashSet<>();
+
+    for (var shipment : shipments) {
+      if (shipment.getFrom() != null) nodeIds.add(shipment.getFrom().getId());
+      if (shipment.getTo() != null) nodeIds.add(shipment.getTo().getId());
+      if (shipment.getDeliveryManager() != null)
+        managerIds.add(shipment.getDeliveryManager().getId());
     }
-    if (!assigned) throw new BusinessException(CommonErrorCode.FORBIDDEN);
+
+    return new ShipmentInfoIds(nodeIds, managerIds);
   }
 
-  private static void checkIfDeliveryRelatedToUserHub(
-      UserContext user, DeliveryResponseDto delivery) {
-    boolean related = true;
+  private static ShipmentInfoIds getShipmentInfoIds(DeliveryResponseDto delivery) {
+    Set<UUID> nodeIds = new HashSet<>();
+    Set<UUID> managerIds = new HashSet<>();
+
     for (var shipment : delivery.shipments()) {
-      UUID toHubId = shipment.to() != null ? shipment.to().id() : null;
-      UUID fromHubId = shipment.from() != null ? shipment.from().id() : null;
-      if (!user.hubId().equals(toHubId) && !user.hubId().equals(fromHubId)) {
-        related = false;
-        break;
-      }
+      if (shipment.from() != null) nodeIds.add(shipment.from().id());
+      if (shipment.to() != null) nodeIds.add(shipment.to().id());
+      if (shipment.deliveryManager() != null) managerIds.add(shipment.deliveryManager().id());
     }
-    if (!related) throw new BusinessException(CommonErrorCode.FORBIDDEN);
+
+    return new ShipmentInfoIds(nodeIds, managerIds);
+  }
+
+  private static void checkReadAccess(
+      UserContext user, Set<UUID> nodeIds, Set<UUID> deliveryManagerIds) {
+    if (user.role() == MASTER || user.role() == VENDOR) return;
+    if (user.role() == HUB_MANAGER) {
+      checkIfDeliveryRelatedToUserHub(user.hubId(), nodeIds);
+      return;
+    }
+    if (user.role() == DELIVERY_MANAGER) {
+      checkIfAssignedToUser(user.userId(), deliveryManagerIds);
+    }
+  }
+
+  private static void checkIfDeliveryRelatedToUserHub(UUID hubId, Set<UUID> nodeIds) {
+    if (!nodeIds.contains(hubId)) {
+      throw new BusinessException(CommonErrorCode.FORBIDDEN);
+    }
+  }
+
+  private static void checkIfAssignedToUser(UUID userId, Set<UUID> managerIds) {
+    if (!managerIds.contains(userId)) {
+      throw new BusinessException(CommonErrorCode.FORBIDDEN);
   }
 }

--- a/src/main/java/com/followMe/delivery_server/delivery/application/DeliveryPermissionChecker.java
+++ b/src/main/java/com/followMe/delivery_server/delivery/application/DeliveryPermissionChecker.java
@@ -36,6 +36,17 @@ public class DeliveryPermissionChecker {
       default -> throw new BusinessException(CommonErrorCode.FORBIDDEN);
     }
   }
+
+  public static void checkDeleteAccess(UserContext user, Delivery delivery) {
+    switch (user.role()) {
+      case MASTER -> {}
+      case HUB_MANAGER -> {
+        Shipment firstShipment = delivery.getShipments().getFirst();
+        if (user.hubId() == null || !user.hubId().equals(firstShipment.getFrom().getId())) {
+          throw new BusinessException(CommonErrorCode.FORBIDDEN);
+        }
+      }
+      default -> throw new BusinessException(CommonErrorCode.FORBIDDEN);
     }
   }
 
@@ -98,5 +109,6 @@ public class DeliveryPermissionChecker {
   private static void checkIfAssignedToUser(UUID userId, Set<UUID> managerIds) {
     if (!managerIds.contains(userId)) {
       throw new BusinessException(CommonErrorCode.FORBIDDEN);
+    }
   }
 }

--- a/src/main/java/com/followMe/delivery_server/delivery/application/DeliveryService.java
+++ b/src/main/java/com/followMe/delivery_server/delivery/application/DeliveryService.java
@@ -2,10 +2,7 @@ package com.followMe.delivery_server.delivery.application;
 
 import com.followMe.common.pagination.PageRequest;
 import com.followMe.common.pagination.PageResponse;
-import com.followMe.delivery_server.delivery.application.dto.DeliveryCreateResponse;
-import com.followMe.delivery_server.delivery.application.dto.DeliveryResponseDto;
-import com.followMe.delivery_server.delivery.application.dto.DeliverySearchCondition;
-import com.followMe.delivery_server.delivery.application.dto.OrderCreateCommand;
+import com.followMe.delivery_server.delivery.application.dto.*;
 import java.util.UUID;
 
 public interface DeliveryService {

--- a/src/main/java/com/followMe/delivery_server/delivery/application/DeliveryService.java
+++ b/src/main/java/com/followMe/delivery_server/delivery/application/DeliveryService.java
@@ -18,4 +18,6 @@ public interface DeliveryService {
       UserContext user, PageRequest pageRequest, DeliverySearchCondition condition);
 
   DeliveryResponseDto getDeliveryByOrderId(UserContext user, UUID orderId);
+
+  void cancelDelivery(UserContext user, UUID deliveryId);
 }

--- a/src/main/java/com/followMe/delivery_server/delivery/application/DeliveryService.java
+++ b/src/main/java/com/followMe/delivery_server/delivery/application/DeliveryService.java
@@ -20,4 +20,6 @@ public interface DeliveryService {
   DeliveryResponseDto getDeliveryByOrderId(UserContext user, UUID orderId);
 
   void cancelDelivery(UserContext user, UUID deliveryId);
+
+  void deleteDelivery(UserContext user, UUID deliveryId);
 }

--- a/src/main/java/com/followMe/delivery_server/delivery/application/DeliveryServiceImpl.java
+++ b/src/main/java/com/followMe/delivery_server/delivery/application/DeliveryServiceImpl.java
@@ -1,7 +1,6 @@
 package com.followMe.delivery_server.delivery.application;
 
-import static com.followMe.delivery_server.delivery.application.DeliveryPermissionChecker.checkAccess;
-import static com.followMe.delivery_server.delivery.application.DeliveryPermissionChecker.checkListAccess;
+import static com.followMe.delivery_server.delivery.application.DeliveryPermissionChecker.*;
 
 import com.followMe.common.pagination.PageRequest;
 import com.followMe.common.pagination.PageResponse;
@@ -11,6 +10,7 @@ import com.followMe.delivery_server.delivery.application.dto.DeliverySearchCondi
 import com.followMe.delivery_server.delivery.application.dto.OrderCreateCommand;
 import com.followMe.delivery_server.delivery.domain.Delivery;
 import com.followMe.delivery_server.delivery.domain.Node;
+import com.followMe.delivery_server.delivery.domain.exception.DeliveryException;
 import com.followMe.delivery_server.delivery.domain.repository.DeliveryRepository;
 import com.followMe.delivery_server.delivery.infra.hub.HubClient;
 import com.followMe.delivery_server.delivery.infra.query.DeliveryQueryRepository;
@@ -62,5 +62,16 @@ public class DeliveryServiceImpl implements DeliveryService {
         deliveryQueryRepository.findDeliveryByOrderId(orderId);
     checkReadAccess(user, deliveryResponseDto);
     return deliveryResponseDto;
+  }
+
+  @Override
+  @Transactional
+  public void cancelDelivery(UserContext user, UUID deliveryId) {
+    Delivery delivery =
+        deliveryRepository
+            .findById(deliveryId)
+            .orElseThrow(DeliveryException.DeliveryNotFoundException::new);
+    checkCancelAccess(user, delivery);
+    delivery.cancel();
   }
 }

--- a/src/main/java/com/followMe/delivery_server/delivery/application/DeliveryServiceImpl.java
+++ b/src/main/java/com/followMe/delivery_server/delivery/application/DeliveryServiceImpl.java
@@ -4,10 +4,7 @@ import static com.followMe.delivery_server.delivery.application.DeliveryPermissi
 
 import com.followMe.common.pagination.PageRequest;
 import com.followMe.common.pagination.PageResponse;
-import com.followMe.delivery_server.delivery.application.dto.DeliveryCreateResponse;
-import com.followMe.delivery_server.delivery.application.dto.DeliveryResponseDto;
-import com.followMe.delivery_server.delivery.application.dto.DeliverySearchCondition;
-import com.followMe.delivery_server.delivery.application.dto.OrderCreateCommand;
+import com.followMe.delivery_server.delivery.application.dto.*;
 import com.followMe.delivery_server.delivery.domain.Delivery;
 import com.followMe.delivery_server.delivery.domain.Node;
 import com.followMe.delivery_server.delivery.domain.exception.DeliveryException;
@@ -30,7 +27,7 @@ public class DeliveryServiceImpl implements DeliveryService {
 
   @Override
   @Transactional
-  public void createDelivery(OrderCreateCommand command) {
+  public DeliveryCreateResponse createDelivery(OrderCreateCommand command) {
 
     List<Node> nodes = hubClient.getNodes(command.sourceHubId(), command.vendorId()).toDomain();
     Delivery delivery = Delivery.create(command.orderId(), nodes);

--- a/src/main/java/com/followMe/delivery_server/delivery/application/DeliveryServiceImpl.java
+++ b/src/main/java/com/followMe/delivery_server/delivery/application/DeliveryServiceImpl.java
@@ -28,9 +28,9 @@ public class DeliveryServiceImpl implements DeliveryService {
   private final DeliveryQueryRepository deliveryQueryRepository;
   private final HubClient hubClient;
 
-  @Transactional
   @Override
-  public DeliveryCreateResponse createDelivery(OrderCreateCommand command) {
+  @Transactional
+  public void createDelivery(OrderCreateCommand command) {
 
     List<Node> nodes = hubClient.getNodes(command.sourceHubId(), command.vendorId()).toDomain();
     Delivery delivery = Delivery.create(command.orderId(), nodes);
@@ -42,7 +42,7 @@ public class DeliveryServiceImpl implements DeliveryService {
   @Transactional(readOnly = true)
   public DeliveryResponseDto getDelivery(UserContext user, UUID deliveryId) {
     DeliveryResponseDto deliveryResponseDto = deliveryQueryRepository.findDeliveryById(deliveryId);
-    checkAccess(user, deliveryResponseDto);
+    checkReadAccess(user, deliveryResponseDto);
     return deliveryResponseDto;
   }
 
@@ -56,10 +56,11 @@ public class DeliveryServiceImpl implements DeliveryService {
   }
 
   @Override
+  @Transactional(readOnly = true)
   public DeliveryResponseDto getDeliveryByOrderId(UserContext user, UUID orderId) {
     DeliveryResponseDto deliveryResponseDto =
         deliveryQueryRepository.findDeliveryByOrderId(orderId);
-    checkAccess(user, deliveryResponseDto);
+    checkReadAccess(user, deliveryResponseDto);
     return deliveryResponseDto;
   }
 }

--- a/src/main/java/com/followMe/delivery_server/delivery/application/DeliveryServiceImpl.java
+++ b/src/main/java/com/followMe/delivery_server/delivery/application/DeliveryServiceImpl.java
@@ -74,4 +74,15 @@ public class DeliveryServiceImpl implements DeliveryService {
     checkCancelAccess(user, delivery);
     delivery.cancel();
   }
+
+  @Override
+  @Transactional
+  public void deleteDelivery(UserContext user, UUID deliveryId) {
+    Delivery delivery =
+        deliveryRepository
+            .findById(deliveryId)
+            .orElseThrow(DeliveryException.DeliveryNotFoundException::new);
+    checkDeleteAccess(user, delivery);
+    delivery.softDelete(user.userId());
+  }
 }

--- a/src/main/java/com/followMe/delivery_server/delivery/domain/Delivery.java
+++ b/src/main/java/com/followMe/delivery_server/delivery/domain/Delivery.java
@@ -74,5 +74,7 @@ public class Delivery extends BaseAudit {
 
   public void softDelete(UUID deletedBy) {
     super.softDelete(deletedBy.toString());
+    this.shipments.forEach(shipment -> shipment.softDelete(deletedBy.toString()));
+  }
   }
 }

--- a/src/main/java/com/followMe/delivery_server/delivery/domain/Delivery.java
+++ b/src/main/java/com/followMe/delivery_server/delivery/domain/Delivery.java
@@ -68,6 +68,7 @@ public class Delivery extends BaseAudit {
     if (this.status.isTransitionNotAllowed(DeliveryStatus.CANCELLED)) {
       throw new InvalidDeliveryStatusException();
     }
+    this.shipments.forEach(Shipment::cancel);
     this.status = DeliveryStatus.CANCELLED;
   }
 

--- a/src/main/java/com/followMe/delivery_server/delivery/domain/Delivery.java
+++ b/src/main/java/com/followMe/delivery_server/delivery/domain/Delivery.java
@@ -76,5 +76,11 @@ public class Delivery extends BaseAudit {
     super.softDelete(deletedBy.toString());
     this.shipments.forEach(shipment -> shipment.softDelete(deletedBy.toString()));
   }
+
+  public void updateStatus(DeliveryStatus status) {
+    if (this.status.isTransitionNotAllowed(status)) {
+      throw new InvalidDeliveryStatusException();
+    }
+    this.status = status;
   }
 }

--- a/src/main/java/com/followMe/delivery_server/delivery/domain/Delivery.java
+++ b/src/main/java/com/followMe/delivery_server/delivery/domain/Delivery.java
@@ -30,6 +30,7 @@ public class Delivery extends BaseAudit {
   @Column(nullable = false, length = 30)
   private DeliveryStatus status;
 
+  @OrderBy("sequence ASC")
   @OneToMany(mappedBy = "delivery", cascade = CascadeType.ALL, orphanRemoval = true)
   private List<Shipment> shipments = new ArrayList<>();
 

--- a/src/main/java/com/followMe/delivery_server/delivery/domain/Delivery.java
+++ b/src/main/java/com/followMe/delivery_server/delivery/domain/Delivery.java
@@ -2,6 +2,7 @@ package com.followMe.delivery_server.delivery.domain;
 
 import com.followMe.common.entity.BaseAudit;
 import com.followMe.delivery_server.delivery.domain.enums.DeliveryStatus;
+import com.followMe.delivery_server.delivery.domain.enums.ShipmentStatus;
 import com.followMe.delivery_server.delivery.domain.exception.DeliveryException.InvalidDeliveryStatusException;
 import jakarta.persistence.*;
 import java.util.ArrayList;
@@ -26,17 +27,12 @@ public class Delivery extends BaseAudit {
   @AttributeOverrides({@AttributeOverride(name = "value", column = @Column(name = "order_id"))})
   private OrderId orderId;
 
-  @Enumerated(EnumType.STRING)
-  @Column(nullable = false, length = 30)
-  private DeliveryStatus status;
-
   @OrderBy("sequence ASC")
   @OneToMany(mappedBy = "delivery", cascade = CascadeType.ALL, orphanRemoval = true)
   private List<Shipment> shipments = new ArrayList<>();
 
   private Delivery(OrderId orderId, List<Node> nodes) {
     this.orderId = orderId;
-    this.status = DeliveryStatus.READY;
     this.shipments = Shipment.createList(this, nodes);
   }
 
@@ -44,44 +40,32 @@ public class Delivery extends BaseAudit {
     return new Delivery(OrderId.of(orderId), nodes);
   }
 
-  public void start() {
-    if (this.status.isTransitionNotAllowed(DeliveryStatus.IN_PROGRESS)) {
-      throw new InvalidDeliveryStatusException();
+  public DeliveryStatus getDeliveryStatus() {
+    if (this.shipments.stream().anyMatch(s -> s.getStatus() == ShipmentStatus.FAILED)) {
+      return DeliveryStatus.FAILED;
     }
-    this.status = DeliveryStatus.IN_PROGRESS;
-  }
-
-  public void complete() {
-    if (this.status.isTransitionNotAllowed(DeliveryStatus.COMPLETED)) {
-      throw new InvalidDeliveryStatusException();
+    if (this.shipments.stream().allMatch(s -> s.getStatus() == ShipmentStatus.COMPLETED)) {
+      return DeliveryStatus.COMPLETED;
     }
-    this.status = DeliveryStatus.COMPLETED;
-  }
-
-  public void fail() {
-    if (this.status.isTransitionNotAllowed(DeliveryStatus.FAILED)) {
-      throw new InvalidDeliveryStatusException();
+    if (this.shipments.stream().anyMatch(s -> ShipmentStatus.isInProgress(s.getStatus()))) {
+      return DeliveryStatus.IN_PROGRESS;
     }
-    this.status = DeliveryStatus.FAILED;
+    if (this.shipments.stream().allMatch(s -> s.getStatus() == ShipmentStatus.CANCELLED)) {
+      return DeliveryStatus.CANCELLED;
+    }
+    return DeliveryStatus.READY;
   }
 
   public void cancel() {
-    if (this.status.isTransitionNotAllowed(DeliveryStatus.CANCELLED)) {
+    if (this.getDeliveryStatus() != DeliveryStatus.READY
+        || this.getDeliveryStatus() != DeliveryStatus.FAILED) {
       throw new InvalidDeliveryStatusException();
     }
     this.shipments.forEach(Shipment::cancel);
-    this.status = DeliveryStatus.CANCELLED;
   }
 
   public void softDelete(UUID deletedBy) {
     super.softDelete(deletedBy);
     this.shipments.forEach(shipment -> shipment.softDelete(deletedBy));
-  }
-
-  public void updateStatus(DeliveryStatus status) {
-    if (this.status.isTransitionNotAllowed(status)) {
-      throw new InvalidDeliveryStatusException();
-    }
-    this.status = status;
   }
 }

--- a/src/main/java/com/followMe/delivery_server/delivery/domain/Delivery.java
+++ b/src/main/java/com/followMe/delivery_server/delivery/domain/Delivery.java
@@ -73,8 +73,8 @@ public class Delivery extends BaseAudit {
   }
 
   public void softDelete(UUID deletedBy) {
-    super.softDelete(deletedBy.toString());
-    this.shipments.forEach(shipment -> shipment.softDelete(deletedBy.toString()));
+    super.softDelete(deletedBy);
+    this.shipments.forEach(shipment -> shipment.softDelete(deletedBy));
   }
 
   public void updateStatus(DeliveryStatus status) {

--- a/src/main/java/com/followMe/delivery_server/delivery/domain/Shipment.java
+++ b/src/main/java/com/followMe/delivery_server/delivery/domain/Shipment.java
@@ -67,7 +67,7 @@ public class Shipment extends BaseAudit {
   })
   private DeliveryManager deliveryManager;
 
-  @Version private Integer _version;
+  @Version private int _version;
 
   private Instant shippedAt;
   private Instant arrivedAt;

--- a/src/main/java/com/followMe/delivery_server/delivery/domain/enums/DeliveryStatus.java
+++ b/src/main/java/com/followMe/delivery_server/delivery/domain/enums/DeliveryStatus.java
@@ -13,7 +13,7 @@ public enum DeliveryStatus {
     READY.allowedTransitions = Set.of(IN_PROGRESS, CANCELLED);
     IN_PROGRESS.allowedTransitions = Set.of(COMPLETED, FAILED);
     COMPLETED.allowedTransitions = Set.of();
-    FAILED.allowedTransitions = Set.of();
+    FAILED.allowedTransitions = Set.of(CANCELLED);
     CANCELLED.allowedTransitions = Set.of();
   }
 

--- a/src/main/java/com/followMe/delivery_server/delivery/domain/enums/ShipmentStatus.java
+++ b/src/main/java/com/followMe/delivery_server/delivery/domain/enums/ShipmentStatus.java
@@ -17,7 +17,7 @@ public enum ShipmentStatus {
     IN_TRANSIT.allowedTransitions = Set.of(ARRIVED, FAILED);
     ARRIVED.allowedTransitions = Set.of(COMPLETED, FAILED);
     COMPLETED.allowedTransitions = Set.of();
-    FAILED.allowedTransitions = Set.of();
+    FAILED.allowedTransitions = Set.of(CANCELLED);
     CANCELLED.allowedTransitions = Set.of();
   }
 

--- a/src/main/java/com/followMe/delivery_server/delivery/domain/repository/DeliveryRepository.java
+++ b/src/main/java/com/followMe/delivery_server/delivery/domain/repository/DeliveryRepository.java
@@ -1,9 +1,15 @@
 package com.followMe.delivery_server.delivery.domain.repository;
 
 import com.followMe.delivery_server.delivery.domain.Delivery;
+import java.util.Optional;
 import java.util.UUID;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 
 @Repository
-public interface DeliveryRepository extends JpaRepository<Delivery, UUID> {}
+public interface DeliveryRepository extends JpaRepository<Delivery, UUID> {
+
+  @Query("SELECT d FROM Delivery d LEFT JOIN FETCH d.shipments WHERE d.id = :id")
+  Optional<Delivery> findById(UUID id);
+}

--- a/src/main/java/com/followMe/delivery_server/delivery/domain/repository/DeliveryRepository.java
+++ b/src/main/java/com/followMe/delivery_server/delivery/domain/repository/DeliveryRepository.java
@@ -10,6 +10,6 @@ import org.springframework.stereotype.Repository;
 @Repository
 public interface DeliveryRepository extends JpaRepository<Delivery, UUID> {
 
-  @Query("SELECT d FROM Delivery d LEFT JOIN FETCH d.shipments WHERE d.id = :id")
+  @Query("SELECT DISTINCT d FROM Delivery d LEFT JOIN FETCH d.shipments WHERE d.id = :id")
   Optional<Delivery> findById(UUID id);
 }

--- a/src/main/java/com/followMe/delivery_server/delivery/infra/hub/HubClient.java
+++ b/src/main/java/com/followMe/delivery_server/delivery/infra/hub/HubClient.java
@@ -6,7 +6,10 @@ import org.springframework.cloud.openfeign.FeignClient;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 
-@FeignClient(name = "hub-service", fallbackFactory = HubClientFallbackFactory.class)
+@FeignClient(
+    name = "hub-service",
+    fallbackFactory = HubClientFallbackFactory.class,
+    primary = false)
 public interface HubClient {
   @GetMapping("/api/hubs/route")
   HubRouteResponse getNodes(@RequestParam UUID sourceHubId, @RequestParam UUID vendorId);

--- a/src/main/java/com/followMe/delivery_server/delivery/infra/hub/HubClientLocalStub.java
+++ b/src/main/java/com/followMe/delivery_server/delivery/infra/hub/HubClientLocalStub.java
@@ -1,6 +1,7 @@
 package com.followMe.delivery_server.delivery.infra.hub;
 
 import com.followMe.delivery_server.delivery.domain.enums.NodeType;
+import com.followMe.delivery_server.delivery.domain.exception.DeliveryException.HubClientUnavailableException;
 import com.followMe.delivery_server.delivery.infra.hub.dto.HubNodeInfo;
 import com.followMe.delivery_server.delivery.infra.hub.dto.HubRouteResponse;
 import java.util.List;
@@ -17,10 +18,15 @@ import org.springframework.stereotype.Component;
 public class HubClientLocalStub implements HubClient {
 
   private static final UUID MIDDLE_HUB_ID = UUID.fromString("dddddddd-0000-0000-0000-000000000002");
+  private static final String UNKNOWN_SUFFIX = "0000-000000000099";
 
   @Override
   public HubRouteResponse getNodes(UUID sourceHubId, UUID vendorId) {
     log.info("[LocalStub] HubClient.getNodes sourceHubId={} vendorId={}", sourceHubId, vendorId);
+    if (sourceHubId.toString().endsWith(UNKNOWN_SUFFIX)
+        || vendorId.toString().endsWith(UNKNOWN_SUFFIX)) {
+      throw new HubClientUnavailableException();
+    }
     return new HubRouteResponse(
         List.of(
             new HubNodeInfo(sourceHubId, NodeType.HUB, "출발 허브", 1),

--- a/src/main/java/com/followMe/delivery_server/delivery/presentation/DeliveryController.java
+++ b/src/main/java/com/followMe/delivery_server/delivery/presentation/DeliveryController.java
@@ -61,4 +61,11 @@ public class DeliveryController {
     DeliveryResponseDto response = deliveryService.getDelivery(user, deliveryId);
     return ApiResponse.ok(response);
   }
+
+  @PatchMapping("/{deliveryId}/cancel")
+  public ResponseEntity<ApiResponse> cancelDelivery(
+      @PathVariable UUID deliveryId, @ModelAttribute UserContext user) {
+    deliveryService.cancelDelivery(user, deliveryId);
+    return ApiResponse.ok();
+  }
 }

--- a/src/main/java/com/followMe/delivery_server/delivery/presentation/DeliveryController.java
+++ b/src/main/java/com/followMe/delivery_server/delivery/presentation/DeliveryController.java
@@ -68,4 +68,11 @@ public class DeliveryController {
     deliveryService.cancelDelivery(user, deliveryId);
     return ApiResponse.ok();
   }
+
+  @DeleteMapping("/{deliveryId}")
+  public ResponseEntity<ApiResponse> deleteDelivery(
+      @PathVariable UUID deliveryId, @ModelAttribute UserContext user) {
+    deliveryService.deleteDelivery(user, deliveryId);
+    return ApiResponse.ok();
+  }
 }

--- a/src/main/java/com/followMe/delivery_server/test/TestResetController.java
+++ b/src/main/java/com/followMe/delivery_server/test/TestResetController.java
@@ -1,0 +1,29 @@
+package com.followMe.delivery_server.test;
+
+import com.followMe.common.response.ApiResponse;
+import javax.sql.DataSource;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Profile;
+import org.springframework.core.io.ClassPathResource;
+import org.springframework.http.ResponseEntity;
+import org.springframework.jdbc.datasource.init.ScriptUtils;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Profile("local")
+@RestController
+@RequestMapping("/internal/test")
+@RequiredArgsConstructor
+public class TestResetController {
+
+  private final DataSource dataSource;
+
+  @PostMapping("/reset")
+  public ResponseEntity<ApiResponse> reset() throws Exception {
+    try (var connection = dataSource.getConnection()) {
+      ScriptUtils.executeSqlScript(connection, new ClassPathResource("mock-data.sql"));
+    }
+    return ApiResponse.ok();
+  }
+}

--- a/src/main/resources/mock-data.sql
+++ b/src/main/resources/mock-data.sql
@@ -1,6 +1,12 @@
 -- 기존 데이터 초기화
-DELETE FROM p_shipment;
-DELETE FROM p_delivery;
+-- =====================================================
+--   psql -h localhost -U postgres -d delivery_db -f docs/mock-data.sql
+-- =====================================================
+
+DELETE
+FROM p_shipment;
+DELETE
+FROM p_delivery;
 
 -- =====================================================
 -- 노드 UUID 정리
@@ -15,27 +21,27 @@ DELETE FROM p_delivery;
 -- =====================================================
 INSERT INTO p_delivery (id, order_id, status, created_at, updated_at, created_by, updated_by)
 VALUES ('aaaaaaaa-0000-0000-0000-000000000001', 'bbbbbbbb-0000-0000-0000-000000000001',
-        'READY', NOW() - INTERVAL '5 days', NOW() - INTERVAL '5 days', 'system', 'system');
+        'READY', NOW() - INTERVAL '5 days', NOW() - INTERVAL '5 days', '00000000-0000-0000-0000-000000000000', '00000000-0000-0000-0000-000000000000');
 
 INSERT INTO p_shipment (id, delivery_id, sequence, status, type,
-    from_node_id, from_node_type, from_node_name,
-    to_node_id, to_node_type, to_node_name,
-    created_at, updated_at, created_by, updated_by)
+                        from_node_id, from_node_type, from_node_name,
+                        to_node_id, to_node_type, to_node_name,
+                        created_at, updated_at, created_by, updated_by, _version)
 VALUES ('cccccccc-0000-0000-0000-000000000001', 'aaaaaaaa-0000-0000-0000-000000000001',
         1, 'PENDING', 'HUB_TO_HUB',
         'dddddddd-0000-0000-0000-000000000001', 'HUB', '서울 허브',
         'dddddddd-0000-0000-0000-000000000002', 'HUB', '부산 허브',
-        NOW() - INTERVAL '5 days', NOW() - INTERVAL '5 days', 'system', 'system');
+        NOW() - INTERVAL '5 days', NOW() - INTERVAL '5 days', '00000000-0000-0000-0000-000000000000', '00000000-0000-0000-0000-000000000000', 0);
 
 INSERT INTO p_shipment (id, delivery_id, sequence, status, type,
-    from_node_id, from_node_type, from_node_name,
-    to_node_id, to_node_type, to_node_name,
-    created_at, updated_at, created_by, updated_by)
+                        from_node_id, from_node_type, from_node_name,
+                        to_node_id, to_node_type, to_node_name,
+                        created_at, updated_at, created_by, updated_by, _version)
 VALUES ('cccccccc-0000-0000-0000-000000000002', 'aaaaaaaa-0000-0000-0000-000000000001',
         2, 'PENDING', 'HUB_TO_VENDOR',
         'dddddddd-0000-0000-0000-000000000002', 'HUB', '부산 허브',
         'dddddddd-0000-0000-0000-000000000003', 'VENDOR', '부산 업체',
-        NOW() - INTERVAL '5 days', NOW() - INTERVAL '5 days', 'system', 'system');
+        NOW() - INTERVAL '5 days', NOW() - INTERVAL '5 days', '00000000-0000-0000-0000-000000000000', '00000000-0000-0000-0000-000000000000', 0);
 
 -- =====================================================
 -- DELIVERY 2: IN_PROGRESS | 서울→서울업체 | 홍길동 배송중
@@ -43,21 +49,21 @@ VALUES ('cccccccc-0000-0000-0000-000000000002', 'aaaaaaaa-0000-0000-0000-0000000
 -- =====================================================
 INSERT INTO p_delivery (id, order_id, status, created_at, updated_at, created_by, updated_by)
 VALUES ('aaaaaaaa-0000-0000-0000-000000000002', 'bbbbbbbb-0000-0000-0000-000000000002',
-        'IN_PROGRESS', NOW() - INTERVAL '3 days', NOW() - INTERVAL '2 days', 'system', 'system');
+        'IN_PROGRESS', NOW() - INTERVAL '3 days', NOW() - INTERVAL '2 days', '00000000-0000-0000-0000-000000000000', '00000000-0000-0000-0000-000000000000');
 
 INSERT INTO p_shipment (id, delivery_id, sequence, status, type,
-    from_node_id, from_node_type, from_node_name,
-    to_node_id, to_node_type, to_node_name,
-    delivery_manager_id, delivery_manager_name,
-    shipped_at,
-    created_at, updated_at, created_by, updated_by)
+                        from_node_id, from_node_type, from_node_name,
+                        to_node_id, to_node_type, to_node_name,
+                        delivery_manager_id, delivery_manager_name,
+                        shipped_at,
+                        created_at, updated_at, created_by, updated_by, _version)
 VALUES ('cccccccc-0000-0000-0000-000000000003', 'aaaaaaaa-0000-0000-0000-000000000002',
         1, 'SHIPPED', 'HUB_TO_VENDOR',
         'dddddddd-0000-0000-0000-000000000001', 'HUB', '서울 허브',
         'dddddddd-0000-0000-0000-000000000004', 'VENDOR', '서울 업체',
         'eeeeeeee-0000-0000-0000-000000000001', '홍길동',
         NOW() - INTERVAL '2 days',
-        NOW() - INTERVAL '3 days', NOW() - INTERVAL '2 days', 'system', 'system');
+        NOW() - INTERVAL '3 days', NOW() - INTERVAL '2 days', '00000000-0000-0000-0000-000000000000', '00000000-0000-0000-0000-000000000000', 0);
 
 -- =====================================================
 -- DELIVERY 3: IN_PROGRESS | 서울→부산→대구→대구업체 | 홍길동 이동중 (1구간 완료)
@@ -66,45 +72,45 @@ VALUES ('cccccccc-0000-0000-0000-000000000003', 'aaaaaaaa-0000-0000-0000-0000000
 -- =====================================================
 INSERT INTO p_delivery (id, order_id, status, created_at, updated_at, created_by, updated_by)
 VALUES ('aaaaaaaa-0000-0000-0000-000000000003', 'bbbbbbbb-0000-0000-0000-000000000003',
-        'IN_PROGRESS', NOW() - INTERVAL '4 days', NOW() - INTERVAL '1 day', 'system', 'system');
+        'IN_PROGRESS', NOW() - INTERVAL '4 days', NOW() - INTERVAL '1 day', '00000000-0000-0000-0000-000000000000', '00000000-0000-0000-0000-000000000000');
 
 INSERT INTO p_shipment (id, delivery_id, sequence, status, type,
-    from_node_id, from_node_type, from_node_name,
-    to_node_id, to_node_type, to_node_name,
-    delivery_manager_id, delivery_manager_name,
-    shipped_at, arrived_at, completed_at,
-    created_at, updated_at, created_by, updated_by)
+                        from_node_id, from_node_type, from_node_name,
+                        to_node_id, to_node_type, to_node_name,
+                        delivery_manager_id, delivery_manager_name,
+                        shipped_at, arrived_at, completed_at,
+                        created_at, updated_at, created_by, updated_by, _version)
 VALUES ('cccccccc-0000-0000-0000-000000000004', 'aaaaaaaa-0000-0000-0000-000000000003',
         1, 'COMPLETED', 'HUB_TO_HUB',
         'dddddddd-0000-0000-0000-000000000001', 'HUB', '서울 허브',
         'dddddddd-0000-0000-0000-000000000002', 'HUB', '부산 허브',
         'eeeeeeee-0000-0000-0000-000000000001', '홍길동',
         NOW() - INTERVAL '3 days', NOW() - INTERVAL '2 days', NOW() - INTERVAL '2 days',
-        NOW() - INTERVAL '4 days', NOW() - INTERVAL '2 days', 'system', 'system');
+        NOW() - INTERVAL '4 days', NOW() - INTERVAL '2 days', '00000000-0000-0000-0000-000000000000', '00000000-0000-0000-0000-000000000000', 0);
 
 INSERT INTO p_shipment (id, delivery_id, sequence, status, type,
-    from_node_id, from_node_type, from_node_name,
-    to_node_id, to_node_type, to_node_name,
-    delivery_manager_id, delivery_manager_name,
-    shipped_at,
-    created_at, updated_at, created_by, updated_by)
+                        from_node_id, from_node_type, from_node_name,
+                        to_node_id, to_node_type, to_node_name,
+                        delivery_manager_id, delivery_manager_name,
+                        shipped_at,
+                        created_at, updated_at, created_by, updated_by, _version)
 VALUES ('cccccccc-0000-0000-0000-000000000005', 'aaaaaaaa-0000-0000-0000-000000000003',
         2, 'IN_TRANSIT', 'HUB_TO_HUB',
         'dddddddd-0000-0000-0000-000000000002', 'HUB', '부산 허브',
         'dddddddd-0000-0000-0000-000000000005', 'HUB', '대구 허브',
         'eeeeeeee-0000-0000-0000-000000000001', '홍길동',
         NOW() - INTERVAL '1 day',
-        NOW() - INTERVAL '4 days', NOW() - INTERVAL '1 day', 'system', 'system');
+        NOW() - INTERVAL '4 days', NOW() - INTERVAL '1 day', '00000000-0000-0000-0000-000000000000', '00000000-0000-0000-0000-000000000000', 0);
 
 INSERT INTO p_shipment (id, delivery_id, sequence, status, type,
-    from_node_id, from_node_type, from_node_name,
-    to_node_id, to_node_type, to_node_name,
-    created_at, updated_at, created_by, updated_by)
+                        from_node_id, from_node_type, from_node_name,
+                        to_node_id, to_node_type, to_node_name,
+                        created_at, updated_at, created_by, updated_by, _version)
 VALUES ('cccccccc-0000-0000-0000-000000000006', 'aaaaaaaa-0000-0000-0000-000000000003',
         3, 'PENDING', 'HUB_TO_VENDOR',
         'dddddddd-0000-0000-0000-000000000005', 'HUB', '대구 허브',
         'dddddddd-0000-0000-0000-000000000006', 'VENDOR', '대구 업체',
-        NOW() - INTERVAL '4 days', NOW() - INTERVAL '4 days', 'system', 'system');
+        NOW() - INTERVAL '4 days', NOW() - INTERVAL '4 days', '00000000-0000-0000-0000-000000000000', '00000000-0000-0000-0000-000000000000', 0);
 
 -- =====================================================
 -- DELIVERY 4: COMPLETED | 부산→부산업체 | 김철수 완료
@@ -112,21 +118,21 @@ VALUES ('cccccccc-0000-0000-0000-000000000006', 'aaaaaaaa-0000-0000-0000-0000000
 -- =====================================================
 INSERT INTO p_delivery (id, order_id, status, created_at, updated_at, created_by, updated_by)
 VALUES ('aaaaaaaa-0000-0000-0000-000000000004', 'bbbbbbbb-0000-0000-0000-000000000004',
-        'COMPLETED', NOW() - INTERVAL '10 days', NOW() - INTERVAL '7 days', 'system', 'system');
+        'COMPLETED', NOW() - INTERVAL '10 days', NOW() - INTERVAL '7 days', '00000000-0000-0000-0000-000000000000', '00000000-0000-0000-0000-000000000000');
 
 INSERT INTO p_shipment (id, delivery_id, sequence, status, type,
-    from_node_id, from_node_type, from_node_name,
-    to_node_id, to_node_type, to_node_name,
-    delivery_manager_id, delivery_manager_name,
-    shipped_at, arrived_at, completed_at,
-    created_at, updated_at, created_by, updated_by)
+                        from_node_id, from_node_type, from_node_name,
+                        to_node_id, to_node_type, to_node_name,
+                        delivery_manager_id, delivery_manager_name,
+                        shipped_at, arrived_at, completed_at,
+                        created_at, updated_at, created_by, updated_by, _version)
 VALUES ('cccccccc-0000-0000-0000-000000000007', 'aaaaaaaa-0000-0000-0000-000000000004',
         1, 'COMPLETED', 'HUB_TO_VENDOR',
         'dddddddd-0000-0000-0000-000000000002', 'HUB', '부산 허브',
         'dddddddd-0000-0000-0000-000000000003', 'VENDOR', '부산 업체',
         'eeeeeeee-0000-0000-0000-000000000002', '김철수',
         NOW() - INTERVAL '9 days', NOW() - INTERVAL '8 days', NOW() - INTERVAL '7 days',
-        NOW() - INTERVAL '10 days', NOW() - INTERVAL '7 days', 'system', 'system');
+        NOW() - INTERVAL '10 days', NOW() - INTERVAL '7 days', '00000000-0000-0000-0000-000000000000', '00000000-0000-0000-0000-000000000000', 0);
 
 -- =====================================================
 -- DELIVERY 5: READY | 서울→부산→부산업체 | 이영희 배정 대기
@@ -134,26 +140,26 @@ VALUES ('cccccccc-0000-0000-0000-000000000007', 'aaaaaaaa-0000-0000-0000-0000000
 -- =====================================================
 INSERT INTO p_delivery (id, order_id, status, created_at, updated_at, created_by, updated_by)
 VALUES ('aaaaaaaa-0000-0000-0000-000000000005', 'bbbbbbbb-0000-0000-0000-000000000005',
-        'READY', NOW() - INTERVAL '1 day', NOW() - INTERVAL '1 day', 'system', 'system');
+        'READY', NOW() - INTERVAL '1 day', NOW() - INTERVAL '1 day', '00000000-0000-0000-0000-000000000000', '00000000-0000-0000-0000-000000000000');
 
 INSERT INTO p_shipment (id, delivery_id, sequence, status, type,
-    from_node_id, from_node_type, from_node_name,
-    to_node_id, to_node_type, to_node_name,
-    delivery_manager_id, delivery_manager_name,
-    created_at, updated_at, created_by, updated_by)
+                        from_node_id, from_node_type, from_node_name,
+                        to_node_id, to_node_type, to_node_name,
+                        delivery_manager_id, delivery_manager_name,
+                        created_at, updated_at, created_by, updated_by, _version)
 VALUES ('cccccccc-0000-0000-0000-000000000008', 'aaaaaaaa-0000-0000-0000-000000000005',
         1, 'PENDING', 'HUB_TO_HUB',
         'dddddddd-0000-0000-0000-000000000001', 'HUB', '서울 허브',
         'dddddddd-0000-0000-0000-000000000002', 'HUB', '부산 허브',
         'eeeeeeee-0000-0000-0000-000000000003', '이영희',
-        NOW() - INTERVAL '1 day', NOW() - INTERVAL '1 day', 'system', 'system');
+        NOW() - INTERVAL '1 day', NOW() - INTERVAL '1 day', '00000000-0000-0000-0000-000000000000', '00000000-0000-0000-0000-000000000000', 0);
 
 INSERT INTO p_shipment (id, delivery_id, sequence, status, type,
-    from_node_id, from_node_type, from_node_name,
-    to_node_id, to_node_type, to_node_name,
-    created_at, updated_at, created_by, updated_by)
+                        from_node_id, from_node_type, from_node_name,
+                        to_node_id, to_node_type, to_node_name,
+                        created_at, updated_at, created_by, updated_by, _version)
 VALUES ('cccccccc-0000-0000-0000-000000000009', 'aaaaaaaa-0000-0000-0000-000000000005',
         2, 'PENDING', 'HUB_TO_VENDOR',
         'dddddddd-0000-0000-0000-000000000002', 'HUB', '부산 허브',
         'dddddddd-0000-0000-0000-000000000003', 'VENDOR', '부산 업체',
-        NOW() - INTERVAL '1 day', NOW() - INTERVAL '1 day', 'system', 'system');
+        NOW() - INTERVAL '1 day', NOW() - INTERVAL '1 day', '00000000-0000-0000-0000-000000000000', '00000000-0000-0000-0000-000000000000', 0);


### PR DESCRIPTION
### 📌 관련 이슈
- close #6 

### 💡 작업 내용
- 배송 취소 API (하위 Shipment 상태 cascade 처리)                                                         
- 배송 삭제 API (soft delete, 하위 Shipment cascade)   
- 취소/삭제 역할별 권한 체크 
- `@Version int` NPE 버그 수정 (wrapper → primitive)      
-  HTTP 테스트 전체 정비 

### 🔍 변경 이유
- 배송 상태 변경(취소) 및 삭제 기능 요구사항 구현                                                         
- `@Version Integer`가 DB 기본값 null로 인해 flush 시 NPE 발생                                            
- 테스트 실행 순서에 따라 상태가 오염되는 문제 해결 

### 📝 리뷰 포인트 (선택)
- `Delivery.cancel()` / `softDelete()`: Shipment cascade 처리 방식  
- `DeliveryPermissionChecker`: 역할별 cancel/delete 권한 로직 (switch 분기)

### 🧠 기타 참고 사항
 Spring Data Auditing 설정 (`AuditorAware<UUID>`) 
`POST /internal/test/reset`: local 전용 목 데이터 초기화 엔드포인트 
`local` 프로파일에서 `HubClientLocalStub` 등 테스트 위해 생성 