### PR TITLE
[FEAT]Shipment 조회  및 상태 변경

### DIFF
--- a/docs/shipment.http
+++ b/docs/shipment.http
@@ -1,0 +1,400 @@
+### [Setup] 테스트 전 데이터 초기화
+POST http://localhost:8081/internal/test/reset
+
+> {%
+    client.test("Setup: 데이터 초기화", function() {
+        client.assert(response.status === 200, "초기화 실패: " + response.status);
+    });
+%}
+
+### ===== 배송 구간 목록 조회 (GET /deliveries/{deliveryId}/shipments) =====
+
+### 구간 목록 (마스터) - 배송1 (서울→부산→부산업체)
+GET http://localhost:8081/api/v1/deliveries/aaaaaaaa-0000-0000-0000-000000000001/shipments
+X-User-Id: cccccccc-0000-0000-0000-000000000001
+X-User-Role: MASTER
+
+> {%
+    client.log(JSON.stringify(response.body, null, 2));
+    client.test("구간 목록 (마스터)", function() {
+        client.assert(response.status === 200, "status 200 기대, 실제: " + response.status);
+        client.assert(response.body.success === true, "success=true 기대");
+        client.assert(response.body.data.length === 2, "구간 2개 기대");
+    });
+%}
+
+### 구간 목록 (허브 관리자 - 서울 허브, 배송1에 포함)
+GET http://localhost:8081/api/v1/deliveries/aaaaaaaa-0000-0000-0000-000000000001/shipments
+X-User-Id: cccccccc-0000-0000-0000-000000000002
+X-User-Role: HUB_MANAGER
+X-Hub-Id: dddddddd-0000-0000-0000-000000000001
+
+> {%
+    client.log(JSON.stringify(response.body, null, 2));
+    client.test("구간 목록 (허브 관리자 - 관련 허브)", function() {
+        client.assert(response.status === 200, "status 200 기대, 실제: " + response.status);
+        client.assert(response.body.success === true, "success=true 기대");
+    });
+%}
+
+### 구간 목록 (배송 담당자 - 홍길동, 배송3 담당)
+GET http://localhost:8081/api/v1/deliveries/aaaaaaaa-0000-0000-0000-000000000003/shipments
+X-User-Id: eeeeeeee-0000-0000-0000-000000000001
+X-User-Role: DELIVERY_MANAGER
+
+> {%
+    client.log(JSON.stringify(response.body, null, 2));
+    client.test("구간 목록 (배송 담당자 - 본인 담당)", function() {
+        client.assert(response.status === 200, "status 200 기대, 실제: " + response.status);
+        client.assert(response.body.success === true, "success=true 기대");
+    });
+%}
+
+### [실패 예상] 허브 관리자 - 관련 없는 허브
+GET http://localhost:8081/api/v1/deliveries/aaaaaaaa-0000-0000-0000-000000000001/shipments
+X-User-Id: cccccccc-0000-0000-0000-000000000002
+X-User-Role: HUB_MANAGER
+X-Hub-Id: dddddddd-0000-0000-0000-000000000099
+
+> {%
+    client.log(JSON.stringify(response.body, null, 2));
+    client.test("[실패 예상] 구간 목록 - 권한 없는 허브 관리자", function() {
+        client.assert(response.body.success === false, "success=false 기대");
+    });
+%}
+
+### [실패 예상] 배송 담당자 - 본인 미배정 배송 (배송1은 담당자 없음)
+GET http://localhost:8081/api/v1/deliveries/aaaaaaaa-0000-0000-0000-000000000001/shipments
+X-User-Id: eeeeeeee-0000-0000-0000-000000000001
+X-User-Role: DELIVERY_MANAGER
+
+> {%
+    client.log(JSON.stringify(response.body, null, 2));
+    client.test("[실패 예상] 구간 목록 - 미배정 배송 담당자", function() {
+        client.assert(response.body.success === false, "success=false 기대");
+    });
+%}
+
+### [실패 예상] 존재하지 않는 배송 ID
+GET http://localhost:8081/api/v1/deliveries/aaaaaaaa-0000-0000-0000-000000000099/shipments
+X-User-Id: cccccccc-0000-0000-0000-000000000001
+X-User-Role: MASTER
+
+> {%
+    client.log(JSON.stringify(response.body, null, 2));
+    client.test("[실패 예상] 구간 목록 - 존재하지 않는 배송", function() {
+        client.assert(response.body.success === false, "success=false 기대");
+    });
+%}
+
+### ===== 배송 구간 단건 조회 (GET /shipments/{shipmentId}) =====
+
+### 단건 조회 (마스터) - 배송3 seq2 홍길동 IN_TRANSIT
+GET http://localhost:8081/api/v1/shipments/cccccccc-0000-0000-0000-000000000005
+X-User-Id: cccccccc-0000-0000-0000-000000000001
+X-User-Role: MASTER
+
+> {%
+    client.log(JSON.stringify(response.body, null, 2));
+    client.test("단건 조회 (마스터)", function() {
+        client.assert(response.status === 200, "status 200 기대, 실제: " + response.status);
+        client.assert(response.body.success === true, "success=true 기대");
+    });
+%}
+
+### 단건 조회 (배송 담당자 - 홍길동, 본인 배정)
+GET http://localhost:8081/api/v1/shipments/cccccccc-0000-0000-0000-000000000005
+X-User-Id: eeeeeeee-0000-0000-0000-000000000001
+X-User-Role: DELIVERY_MANAGER
+
+> {%
+    client.log(JSON.stringify(response.body, null, 2));
+    client.test("단건 조회 (배송 담당자 - 본인 배정)", function() {
+        client.assert(response.status === 200, "status 200 기대, 실제: " + response.status);
+        client.assert(response.body.success === true, "success=true 기대");
+    });
+%}
+
+### 단건 조회 (허브 관리자 - 부산 허브 포함 구간)
+GET http://localhost:8081/api/v1/shipments/cccccccc-0000-0000-0000-000000000005
+X-User-Id: cccccccc-0000-0000-0000-000000000002
+X-User-Role: HUB_MANAGER
+X-Hub-Id: dddddddd-0000-0000-0000-000000000002
+
+> {%
+    client.log(JSON.stringify(response.body, null, 2));
+    client.test("단건 조회 (허브 관리자 - 관련 허브)", function() {
+        client.assert(response.status === 200, "status 200 기대, 실제: " + response.status);
+        client.assert(response.body.success === true, "success=true 기대");
+    });
+%}
+
+### [실패 예상] 배송 담당자 - 타인 배정 구간 (김철수가 홍길동 구간 접근)
+GET http://localhost:8081/api/v1/shipments/cccccccc-0000-0000-0000-000000000005
+X-User-Id: eeeeeeee-0000-0000-0000-000000000002
+X-User-Role: DELIVERY_MANAGER
+
+> {%
+    client.log(JSON.stringify(response.body, null, 2));
+    client.test("[실패 예상] 단건 조회 - 타인 배정 구간", function() {
+        client.assert(response.body.success === false, "success=false 기대");
+    });
+%}
+
+### [실패 예상] 허브 관리자 - 관련 없는 허브
+GET http://localhost:8081/api/v1/shipments/cccccccc-0000-0000-0000-000000000005
+X-User-Id: cccccccc-0000-0000-0000-000000000002
+X-User-Role: HUB_MANAGER
+X-Hub-Id: dddddddd-0000-0000-0000-000000000099
+
+> {%
+    client.log(JSON.stringify(response.body, null, 2));
+    client.test("[실패 예상] 단건 조회 - 권한 없는 허브 관리자", function() {
+        client.assert(response.body.success === false, "success=false 기대");
+    });
+%}
+
+### [실패 예상] 존재하지 않는 구간 ID
+GET http://localhost:8081/api/v1/shipments/cccccccc-0000-0000-0000-000000000099
+X-User-Id: cccccccc-0000-0000-0000-000000000001
+X-User-Role: MASTER
+
+> {%
+    client.log(JSON.stringify(response.body, null, 2));
+    client.test("[실패 예상] 단건 조회 - 존재하지 않는 구간", function() {
+        client.assert(response.body.success === false, "success=false 기대");
+        client.assert(response.body.error.code === "D004", "에러코드 D004 기대");
+    });
+%}
+
+### ===== 상태 변경 - 정상 케이스 =====
+
+### [Setup] 상태 변경 테스트 전 초기화
+POST http://localhost:8081/internal/test/reset
+
+> {%
+    client.test("Setup: 데이터 초기화", function() {
+        client.assert(response.status === 200, "초기화 실패: " + response.status);
+    });
+%}
+
+### MASTER - seq1 PENDING→SHIPPED (배송1 cccc-01, 첫 구간이므로 순서 체크 없음)
+PATCH http://localhost:8081/api/v1/shipments/cccccccc-0000-0000-0000-000000000001/status
+Content-Type: application/json
+X-User-Id: cccccccc-0000-0000-0000-000000000001
+X-User-Role: MASTER
+
+{"status": "SHIPPED"}
+
+> {%
+    client.log(JSON.stringify(response.body, null, 2));
+    client.test("상태 변경 PENDING→SHIPPED (마스터)", function() {
+        client.assert(response.status === 200, "status 200 기대, 실제: " + response.status);
+        client.assert(response.body.success === true, "success=true 기대");
+    });
+%}
+
+### DELIVERY_MANAGER - 본인 배정 구간 SHIPPED→IN_TRANSIT (배송2 cccc-03, 홍길동)
+PATCH http://localhost:8081/api/v1/shipments/cccccccc-0000-0000-0000-000000000003/status
+Content-Type: application/json
+X-User-Id: eeeeeeee-0000-0000-0000-000000000001
+X-User-Role: DELIVERY_MANAGER
+
+{"status": "IN_TRANSIT"}
+
+> {%
+    client.log(JSON.stringify(response.body, null, 2));
+    client.test("상태 변경 SHIPPED→IN_TRANSIT (배송 담당자)", function() {
+        client.assert(response.status === 200, "status 200 기대, 실제: " + response.status);
+        client.assert(response.body.success === true, "success=true 기대");
+    });
+%}
+
+### MASTER - IN_TRANSIT→ARRIVED (배송3 cccc-05, 홍길동)
+PATCH http://localhost:8081/api/v1/shipments/cccccccc-0000-0000-0000-000000000005/status
+Content-Type: application/json
+X-User-Id: cccccccc-0000-0000-0000-000000000001
+X-User-Role: MASTER
+
+{"status": "ARRIVED"}
+
+> {%
+    client.log(JSON.stringify(response.body, null, 2));
+    client.test("상태 변경 IN_TRANSIT→ARRIVED (마스터)", function() {
+        client.assert(response.status === 200, "status 200 기대, 실제: " + response.status);
+        client.assert(response.body.success === true, "success=true 기대");
+    });
+%}
+
+### ===== 완료 흐름: 마지막 HUB_TO_VENDOR 완료 시 Delivery도 COMPLETED =====
+
+### [Setup] 완료 흐름 전 초기화
+POST http://localhost:8081/internal/test/reset
+
+> {%
+    client.test("Setup: 데이터 초기화", function() {
+        client.assert(response.status === 200, "초기화 실패: " + response.status);
+    });
+%}
+
+### Step1. SHIPPED→IN_TRANSIT (배송2 cccc-03, HUB_TO_VENDOR)
+PATCH http://localhost:8081/api/v1/shipments/cccccccc-0000-0000-0000-000000000003/status
+Content-Type: application/json
+X-User-Id: cccccccc-0000-0000-0000-000000000001
+X-User-Role: MASTER
+
+{"status": "IN_TRANSIT"}
+
+> {%
+    client.test("완료 흐름 Step1: IN_TRANSIT", function() {
+        client.assert(response.status === 200, "status 200 기대, 실제: " + response.status);
+    });
+%}
+
+### Step2. IN_TRANSIT→ARRIVED (배송2 cccc-03)
+PATCH http://localhost:8081/api/v1/shipments/cccccccc-0000-0000-0000-000000000003/status
+Content-Type: application/json
+X-User-Id: cccccccc-0000-0000-0000-000000000001
+X-User-Role: MASTER
+
+{"status": "ARRIVED"}
+
+> {%
+    client.test("완료 흐름 Step2: ARRIVED", function() {
+        client.assert(response.status === 200, "status 200 기대, 실제: " + response.status);
+    });
+%}
+
+### Step3. ARRIVED→COMPLETED (배송2 cccc-03) → Delivery2도 COMPLETED로 전환되어야 함
+PATCH http://localhost:8081/api/v1/shipments/cccccccc-0000-0000-0000-000000000003/status
+Content-Type: application/json
+X-User-Id: cccccccc-0000-0000-0000-000000000001
+X-User-Role: MASTER
+
+{"status": "COMPLETED"}
+
+> {%
+    client.log(JSON.stringify(response.body, null, 2));
+    client.test("완료 흐름 Step3: COMPLETED", function() {
+        client.assert(response.status === 200, "status 200 기대, 실제: " + response.status);
+        client.assert(response.body.success === true, "success=true 기대");
+    });
+%}
+
+### Step4. 배송2 단건 조회 - Delivery 상태가 COMPLETED인지 확인
+GET http://localhost:8081/api/v1/deliveries/aaaaaaaa-0000-0000-0000-000000000002
+X-User-Id: cccccccc-0000-0000-0000-000000000001
+X-User-Role: MASTER
+
+> {%
+    client.log(JSON.stringify(response.body, null, 2));
+    client.test("완료 흐름 Step4: Delivery 상태 COMPLETED 확인", function() {
+        client.assert(response.status === 200, "status 200 기대, 실제: " + response.status);
+        client.assert(response.body.data.status === "COMPLETED", "Delivery 상태 COMPLETED 기대");
+    });
+%}
+
+### ===== 상태 변경 - 실패 케이스 =====
+
+### [Setup] 실패 케이스 전 초기화
+POST http://localhost:8081/internal/test/reset
+
+> {%
+    client.test("Setup: 데이터 초기화", function() {
+        client.assert(response.status === 200, "초기화 실패: " + response.status);
+    });
+%}
+
+### [실패 예상] 순서 위반 - seq1이 PENDING인데 seq2를 SHIP 시도 (배송1 cccc-02)
+PATCH http://localhost:8081/api/v1/shipments/cccccccc-0000-0000-0000-000000000002/status
+Content-Type: application/json
+X-User-Id: cccccccc-0000-0000-0000-000000000001
+X-User-Role: MASTER
+
+{"status": "SHIPPED"}
+
+> {%
+    client.log(JSON.stringify(response.body, null, 2));
+    client.test("[실패 예상] 순서 위반 - 이전 구간 미완료", function() {
+        client.assert(response.body.success === false, "success=false 기대");
+        client.assert(response.body.error.code === "D006", "에러코드 D006 기대");
+    });
+%}
+
+### [실패 예상] 잘못된 상태 전환 - PENDING→COMPLETED (cccc-01)
+PATCH http://localhost:8081/api/v1/shipments/cccccccc-0000-0000-0000-000000000001/status
+Content-Type: application/json
+X-User-Id: cccccccc-0000-0000-0000-000000000001
+X-User-Role: MASTER
+
+{"status": "COMPLETED"}
+
+> {%
+    client.log(JSON.stringify(response.body, null, 2));
+    client.test("[실패 예상] 잘못된 상태 전환 PENDING→COMPLETED", function() {
+        client.assert(response.body.success === false, "success=false 기대");
+        client.assert(response.body.error.code === "D006", "에러코드 D006 기대");
+    });
+%}
+
+### [실패 예상] 배송 담당자 - 타인 배정 구간 상태 변경 (김철수가 홍길동 구간 변경 시도)
+PATCH http://localhost:8081/api/v1/shipments/cccccccc-0000-0000-0000-000000000003/status
+Content-Type: application/json
+X-User-Id: eeeeeeee-0000-0000-0000-000000000002
+X-User-Role: DELIVERY_MANAGER
+
+{"status": "IN_TRANSIT"}
+
+> {%
+    client.log(JSON.stringify(response.body, null, 2));
+    client.test("[실패 예상] 상태 변경 - 타인 배정 구간", function() {
+        client.assert(response.body.success === false, "success=false 기대");
+    });
+%}
+
+### [실패 예상] 배송 담당자 - 담당자 미배정 구간 상태 변경 (cccc-01, 담당자 없음)
+PATCH http://localhost:8081/api/v1/shipments/cccccccc-0000-0000-0000-000000000001/status
+Content-Type: application/json
+X-User-Id: eeeeeeee-0000-0000-0000-000000000001
+X-User-Role: DELIVERY_MANAGER
+
+{"status": "SHIPPED"}
+
+> {%
+    client.log(JSON.stringify(response.body, null, 2));
+    client.test("[실패 예상] 상태 변경 - 미배정 구간 (배송 담당자)", function() {
+        client.assert(response.body.success === false, "success=false 기대");
+    });
+%}
+
+### [실패 예상] HUB_MANAGER는 상태 변경 불가
+PATCH http://localhost:8081/api/v1/shipments/cccccccc-0000-0000-0000-000000000003/status
+Content-Type: application/json
+X-User-Id: cccccccc-0000-0000-0000-000000000002
+X-User-Role: HUB_MANAGER
+X-Hub-Id: dddddddd-0000-0000-0000-000000000001
+
+{"status": "IN_TRANSIT"}
+
+> {%
+    client.log(JSON.stringify(response.body, null, 2));
+    client.test("[실패 예상] 상태 변경 - HUB_MANAGER 권한 없음", function() {
+        client.assert(response.body.success === false, "success=false 기대");
+    });
+%}
+
+### [실패 예상] 존재하지 않는 구간 상태 변경
+PATCH http://localhost:8081/api/v1/shipments/cccccccc-0000-0000-0000-000000000099/status
+Content-Type: application/json
+X-User-Id: cccccccc-0000-0000-0000-000000000001
+X-User-Role: MASTER
+
+{"status": "SHIPPED"}
+
+> {%
+    client.log(JSON.stringify(response.body, null, 2));
+    client.test("[실패 예상] 상태 변경 - 존재하지 않는 구간", function() {
+        client.assert(response.body.success === false, "success=false 기대");
+        client.assert(response.body.error.code === "D004", "에러코드 D004 기대");
+    });
+%}

--- a/src/main/java/com/followMe/delivery_server/delivery/application/DeliveryPermissionChecker.java
+++ b/src/main/java/com/followMe/delivery_server/delivery/application/DeliveryPermissionChecker.java
@@ -12,14 +12,15 @@ import java.util.*;
 
 public class DeliveryPermissionChecker {
 
-  public static void checkReadAccess(UserContext user, DeliveryResponseDto delivery) {
-    ShipmentInfoIds shipmentInfoIds = getShipmentInfoIds(delivery);
+  public static void checkReadAccess(
+      UserContext user, List<DeliveryResponseDto.ShipmentResponse> shipments) {
+    ShipmentInfoIds shipmentInfoIds = getShipmentInfoIdsFromDto(shipments);
 
     checkReadAccess(user, shipmentInfoIds.nodeIds, shipmentInfoIds.managerIds);
   }
 
   public static void checkCancelAccess(UserContext user, Delivery delivery) {
-    ShipmentInfoIds shipmentInfoIds = getShipmentInfoIds(delivery.getShipments());
+    ShipmentInfoIds shipmentInfoIds = getShipmentInfoIdsFromEntity(delivery.getShipments());
     switch (user.role()) {
       case MASTER -> {}
       case HUB_MANAGER -> {
@@ -59,9 +60,22 @@ public class DeliveryPermissionChecker {
     }
   }
 
+  public static void checkShipmentStatusUpdateAccess(UserContext user, Shipment shipment) {
+    switch (user.role()) {
+      case MASTER -> {}
+      case DELIVERY_MANAGER -> {
+        if (shipment.getDeliveryManager() == null
+            || !shipment.getDeliveryManager().getId().equals(user.userId())) {
+          throw new BusinessException(CommonErrorCode.FORBIDDEN);
+        }
+      }
+      default -> throw new BusinessException(CommonErrorCode.FORBIDDEN);
+    }
+  }
+
   private record ShipmentInfoIds(Set<UUID> nodeIds, Set<UUID> managerIds) {}
 
-  private static ShipmentInfoIds getShipmentInfoIds(List<Shipment> shipments) {
+  private static ShipmentInfoIds getShipmentInfoIdsFromEntity(List<Shipment> shipments) {
     Set<UUID> nodeIds = new HashSet<>();
     Set<UUID> managerIds = new HashSet<>();
 
@@ -75,11 +89,12 @@ public class DeliveryPermissionChecker {
     return new ShipmentInfoIds(nodeIds, managerIds);
   }
 
-  private static ShipmentInfoIds getShipmentInfoIds(DeliveryResponseDto delivery) {
+  private static ShipmentInfoIds getShipmentInfoIdsFromDto(
+      List<DeliveryResponseDto.ShipmentResponse> shipments) {
     Set<UUID> nodeIds = new HashSet<>();
     Set<UUID> managerIds = new HashSet<>();
 
-    for (var shipment : delivery.shipments()) {
+    for (var shipment : shipments) {
       if (shipment.from() != null) nodeIds.add(shipment.from().id());
       if (shipment.to() != null) nodeIds.add(shipment.to().id());
       if (shipment.deliveryManager() != null) managerIds.add(shipment.deliveryManager().id());
@@ -90,13 +105,13 @@ public class DeliveryPermissionChecker {
 
   private static void checkReadAccess(
       UserContext user, Set<UUID> nodeIds, Set<UUID> deliveryManagerIds) {
-    if (user.role() == MASTER || user.role() == VENDOR) return;
-    if (user.role() == HUB_MANAGER) {
-      checkIfDeliveryRelatedToUserHub(user.hubId(), nodeIds);
-      return;
-    }
-    if (user.role() == DELIVERY_MANAGER) {
-      checkIfAssignedToUser(user.userId(), deliveryManagerIds);
+    switch (user.role()) {
+      case MASTER, VENDOR -> {}
+      case DELIVERY_MANAGER -> checkIfAssignedToUser(user.userId(), deliveryManagerIds);
+
+      case HUB_MANAGER -> checkIfDeliveryRelatedToUserHub(user.hubId(), nodeIds);
+
+      default -> throw new BusinessException(CommonErrorCode.FORBIDDEN);
     }
   }
 

--- a/src/main/java/com/followMe/delivery_server/delivery/application/DeliveryServiceImpl.java
+++ b/src/main/java/com/followMe/delivery_server/delivery/application/DeliveryServiceImpl.java
@@ -39,7 +39,7 @@ public class DeliveryServiceImpl implements DeliveryService {
   @Transactional(readOnly = true)
   public DeliveryResponseDto getDelivery(UserContext user, UUID deliveryId) {
     DeliveryResponseDto deliveryResponseDto = deliveryQueryRepository.findDeliveryById(deliveryId);
-    checkReadAccess(user, deliveryResponseDto);
+    checkReadAccess(user, deliveryResponseDto.shipments());
     return deliveryResponseDto;
   }
 
@@ -57,7 +57,7 @@ public class DeliveryServiceImpl implements DeliveryService {
   public DeliveryResponseDto getDeliveryByOrderId(UserContext user, UUID orderId) {
     DeliveryResponseDto deliveryResponseDto =
         deliveryQueryRepository.findDeliveryByOrderId(orderId);
-    checkReadAccess(user, deliveryResponseDto);
+    checkReadAccess(user, deliveryResponseDto.shipments());
     return deliveryResponseDto;
   }
 

--- a/src/main/java/com/followMe/delivery_server/delivery/application/ShipmentService.java
+++ b/src/main/java/com/followMe/delivery_server/delivery/application/ShipmentService.java
@@ -1,0 +1,15 @@
+package com.followMe.delivery_server.delivery.application;
+
+import com.followMe.delivery_server.delivery.application.dto.DeliveryResponseDto;
+import com.followMe.delivery_server.delivery.domain.enums.ShipmentStatus;
+import java.util.List;
+import java.util.UUID;
+
+public interface ShipmentService {
+  List<DeliveryResponseDto.ShipmentResponse> getShipmentsByDeliveryId(
+      UserContext user, UUID deliveryId);
+
+  DeliveryResponseDto.ShipmentResponse getShipment(UserContext user, UUID shipmentId);
+
+  void updateStatus(UserContext user, UUID shipmentId, ShipmentStatus status);
+}

--- a/src/main/java/com/followMe/delivery_server/delivery/application/ShipmentServiceImpl.java
+++ b/src/main/java/com/followMe/delivery_server/delivery/application/ShipmentServiceImpl.java
@@ -1,0 +1,33 @@
+package com.followMe.delivery_server.delivery.application;
+
+import static com.followMe.delivery_server.delivery.application.DeliveryPermissionChecker.checkReadAccess;
+import static com.followMe.delivery_server.delivery.application.DeliveryPermissionChecker.checkShipmentStatusUpdateAccess;
+
+import com.followMe.delivery_server.delivery.application.dto.DeliveryResponseDto;
+import com.followMe.delivery_server.delivery.domain.Shipment;
+import com.followMe.delivery_server.delivery.domain.enums.ShipmentStatus;
+import com.followMe.delivery_server.delivery.domain.exception.DeliveryException;
+import com.followMe.delivery_server.delivery.domain.repository.DeliveryRepository;
+import com.followMe.delivery_server.delivery.infra.query.DeliveryQueryRepository;
+import java.util.List;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class ShipmentServiceImpl implements ShipmentService {
+
+  private final DeliveryQueryRepository deliveryQueryRepository;
+
+  @Override
+  @Transactional(readOnly = true)
+  public List<DeliveryResponseDto.ShipmentResponse> getShipmentsByDeliveryId(
+      UserContext user, UUID deliveryId) {
+    List<DeliveryResponseDto.ShipmentResponse> shipmentDtoList =
+        deliveryQueryRepository.findShipmentsByDeliveryId(deliveryId);
+    checkReadAccess(user, shipmentDtoList);
+    return shipmentDtoList;
+  }
+}

--- a/src/main/java/com/followMe/delivery_server/delivery/application/ShipmentServiceImpl.java
+++ b/src/main/java/com/followMe/delivery_server/delivery/application/ShipmentServiceImpl.java
@@ -30,4 +30,13 @@ public class ShipmentServiceImpl implements ShipmentService {
     checkReadAccess(user, shipmentDtoList);
     return shipmentDtoList;
   }
+
+  @Override
+  @Transactional(readOnly = true)
+  public DeliveryResponseDto.ShipmentResponse getShipment(UserContext user, UUID shipmentId) {
+    DeliveryResponseDto.ShipmentResponse shipmentResponse =
+        deliveryQueryRepository.findShipmentById(shipmentId);
+    checkReadAccess(user, List.of(shipmentResponse));
+    return shipmentResponse;
+  }
 }

--- a/src/main/java/com/followMe/delivery_server/delivery/application/ShipmentServiceImpl.java
+++ b/src/main/java/com/followMe/delivery_server/delivery/application/ShipmentServiceImpl.java
@@ -26,6 +26,9 @@ public class ShipmentServiceImpl implements ShipmentService {
   @Transactional(readOnly = true)
   public List<DeliveryResponseDto.ShipmentResponse> getShipmentsByDeliveryId(
       UserContext user, UUID deliveryId) {
+    deliveryRepository
+        .findById(deliveryId)
+        .orElseThrow(DeliveryException.DeliveryNotFoundException::new);
     List<DeliveryResponseDto.ShipmentResponse> shipmentDtoList =
         deliveryQueryRepository.findShipmentsByDeliveryId(deliveryId);
     checkReadAccess(user, shipmentDtoList);

--- a/src/main/java/com/followMe/delivery_server/delivery/application/ShipmentServiceImpl.java
+++ b/src/main/java/com/followMe/delivery_server/delivery/application/ShipmentServiceImpl.java
@@ -19,6 +19,7 @@ import org.springframework.transaction.annotation.Transactional;
 @RequiredArgsConstructor
 public class ShipmentServiceImpl implements ShipmentService {
 
+  private final DeliveryRepository deliveryRepository;
   private final DeliveryQueryRepository deliveryQueryRepository;
 
   @Override
@@ -38,5 +39,16 @@ public class ShipmentServiceImpl implements ShipmentService {
         deliveryQueryRepository.findShipmentById(shipmentId);
     checkReadAccess(user, List.of(shipmentResponse));
     return shipmentResponse;
+  }
+
+  @Override
+  @Transactional
+  public void updateStatus(UserContext user, UUID shipmentId, ShipmentStatus status) {
+    Shipment shipment =
+        deliveryRepository
+            .findShipmentById(shipmentId)
+            .orElseThrow(DeliveryException.ShipmentNotFoundException::new);
+    checkShipmentStatusUpdateAccess(user, shipment);
+    shipment.updateShipmentStatus(status);
   }
 }

--- a/src/main/java/com/followMe/delivery_server/delivery/application/dto/ShipmentStatusUpdateRequest.java
+++ b/src/main/java/com/followMe/delivery_server/delivery/application/dto/ShipmentStatusUpdateRequest.java
@@ -1,0 +1,5 @@
+package com.followMe.delivery_server.delivery.application.dto;
+
+import com.followMe.delivery_server.delivery.domain.enums.ShipmentStatus;
+
+public record ShipmentStatusUpdateRequest(ShipmentStatus status) {}

--- a/src/main/java/com/followMe/delivery_server/delivery/application/dto/ShipmentStatusUpdateRequest.java
+++ b/src/main/java/com/followMe/delivery_server/delivery/application/dto/ShipmentStatusUpdateRequest.java
@@ -1,5 +1,6 @@
 package com.followMe.delivery_server.delivery.application.dto;
 
 import com.followMe.delivery_server.delivery.domain.enums.ShipmentStatus;
+import jakarta.validation.constraints.NotNull;
 
-public record ShipmentStatusUpdateRequest(ShipmentStatus status) {}
+public record ShipmentStatusUpdateRequest(@NotNull ShipmentStatus status) {}

--- a/src/main/java/com/followMe/delivery_server/delivery/domain/Delivery.java
+++ b/src/main/java/com/followMe/delivery_server/delivery/domain/Delivery.java
@@ -41,24 +41,28 @@ public class Delivery extends BaseAudit {
   }
 
   public DeliveryStatus getDeliveryStatus() {
-    if (this.shipments.stream().anyMatch(s -> s.getStatus() == ShipmentStatus.FAILED)) {
+    if (this.shipments.stream()
+        .anyMatch(shipment -> shipment.getStatus() == ShipmentStatus.FAILED)) {
       return DeliveryStatus.FAILED;
     }
-    if (this.shipments.stream().allMatch(s -> s.getStatus() == ShipmentStatus.COMPLETED)) {
+    if (this.shipments.stream()
+        .allMatch(shipment -> shipment.getStatus() == ShipmentStatus.COMPLETED)) {
       return DeliveryStatus.COMPLETED;
     }
-    if (this.shipments.stream().anyMatch(s -> ShipmentStatus.isInProgress(s.getStatus()))) {
+    if (this.shipments.stream()
+        .anyMatch(shipment -> ShipmentStatus.isInProgress(shipment.getStatus()))) {
       return DeliveryStatus.IN_PROGRESS;
     }
-    if (this.shipments.stream().allMatch(s -> s.getStatus() == ShipmentStatus.CANCELLED)) {
+    if (this.shipments.stream()
+        .allMatch(shipment -> shipment.getStatus() == ShipmentStatus.CANCELLED)) {
       return DeliveryStatus.CANCELLED;
     }
     return DeliveryStatus.READY;
   }
 
   public void cancel() {
-    if (this.getDeliveryStatus() != DeliveryStatus.READY
-        || this.getDeliveryStatus() != DeliveryStatus.FAILED) {
+    DeliveryStatus currentStatus = this.getDeliveryStatus();
+    if (currentStatus != DeliveryStatus.READY && currentStatus != DeliveryStatus.FAILED) {
       throw new InvalidDeliveryStatusException();
     }
     this.shipments.forEach(Shipment::cancel);

--- a/src/main/java/com/followMe/delivery_server/delivery/domain/Shipment.java
+++ b/src/main/java/com/followMe/delivery_server/delivery/domain/Shipment.java
@@ -7,6 +7,7 @@ import com.followMe.delivery_server.delivery.domain.enums.ShipmentType;
 import com.followMe.delivery_server.delivery.domain.exception.DeliveryException.InvalidNodeInformationException;
 import com.followMe.delivery_server.delivery.domain.exception.DeliveryException.InvalidShipmentStatusException;
 import com.followMe.delivery_server.delivery.domain.exception.DeliveryException.NodeTypeMismatchException;
+import com.followMe.delivery_server.delivery.domain.exception.DeliveryException.ShipmentNotFoundException;
 import jakarta.persistence.*;
 import java.time.Instant;
 import java.util.ArrayList;
@@ -121,8 +122,25 @@ public class Shipment extends BaseAudit {
   }
 
   public void ship() {
+    if (sequence > 1) {
+      Shipment prev = getPreviousShipment();
+      if (prev.getStatus() != ShipmentStatus.COMPLETED) {
+        throw new InvalidShipmentStatusException();
+      }
+    }
     transitionTo(ShipmentStatus.SHIPPED);
     this.shippedAt = Instant.now();
+  }
+
+  private Shipment getPreviousShipment() {
+    Shipment prev;
+    for (Shipment shipment : delivery.getShipments()) {
+      if (shipment.getSequence() == this.sequence - 1) {
+        prev = shipment;
+        return prev;
+      }
+    }
+    throw new ShipmentNotFoundException();
   }
 
   public void transit() {
@@ -145,5 +163,17 @@ public class Shipment extends BaseAudit {
 
   public void cancel() {
     transitionTo(ShipmentStatus.CANCELLED);
+  }
+
+  public void updateShipmentStatus(ShipmentStatus status) {
+    switch (status) {
+      case SHIPPED -> this.ship();
+
+      case IN_TRANSIT -> this.transit();
+      case ARRIVED -> this.arrive();
+      case COMPLETED -> this.complete();
+      case FAILED -> this.fail();
+      default -> throw new InvalidShipmentStatusException();
+    }
   }
 }

--- a/src/main/java/com/followMe/delivery_server/delivery/domain/repository/DeliveryRepository.java
+++ b/src/main/java/com/followMe/delivery_server/delivery/domain/repository/DeliveryRepository.java
@@ -1,15 +1,15 @@
 package com.followMe.delivery_server.delivery.domain.repository;
 
 import com.followMe.delivery_server.delivery.domain.Delivery;
+import com.followMe.delivery_server.delivery.domain.Shipment;
 import java.util.Optional;
 import java.util.UUID;
-import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 
 @Repository
-public interface DeliveryRepository extends JpaRepository<Delivery, UUID> {
+public interface DeliveryRepository {
 
-  @Query("SELECT DISTINCT d FROM Delivery d LEFT JOIN FETCH d.shipments WHERE d.id = :id")
   Optional<Delivery> findById(UUID id);
+
+  Optional<Shipment> findShipmentById(UUID shipmentId);
 }

--- a/src/main/java/com/followMe/delivery_server/delivery/domain/repository/DeliveryRepository.java
+++ b/src/main/java/com/followMe/delivery_server/delivery/domain/repository/DeliveryRepository.java
@@ -8,6 +8,7 @@ import org.springframework.stereotype.Repository;
 
 @Repository
 public interface DeliveryRepository {
+  Delivery save(Delivery delivery);
 
   Optional<Delivery> findById(UUID id);
 

--- a/src/main/java/com/followMe/delivery_server/delivery/infra/persistence/JpaDeliveryRepository.java
+++ b/src/main/java/com/followMe/delivery_server/delivery/infra/persistence/JpaDeliveryRepository.java
@@ -1,0 +1,20 @@
+package com.followMe.delivery_server.delivery.infra.persistence;
+
+import com.followMe.delivery_server.delivery.domain.Delivery;
+import com.followMe.delivery_server.delivery.domain.Shipment;
+import com.followMe.delivery_server.delivery.domain.repository.DeliveryRepository;
+import java.util.Optional;
+import java.util.UUID;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface JpaDeliveryRepository extends DeliveryRepository, JpaRepository<Delivery, UUID> {
+
+  @Query("SELECT DISTINCT d FROM Delivery d LEFT JOIN FETCH d.shipments WHERE d.id = :id")
+  Optional<Delivery> findById(UUID id);
+
+  @Query("SELECT s FROM Shipment s JOIN FETCH s.delivery WHERE s.id = :shipmentId")
+  Optional<Shipment> findShipmentById(UUID shipmentId);
+}

--- a/src/main/java/com/followMe/delivery_server/delivery/infra/query/DeliveryQueryRepository.java
+++ b/src/main/java/com/followMe/delivery_server/delivery/infra/query/DeliveryQueryRepository.java
@@ -88,4 +88,15 @@ public class DeliveryQueryRepository {
     if (records.isEmpty()) throw new DeliveryNotFoundException();
     return recordMapper.toDeliveryResponse(records.getFirst(), records.stream());
   }
+
+  public List<DeliveryResponseDto.ShipmentResponse> findShipmentsByDeliveryId(UUID deliveryId) {
+    Result<Record> records =
+        dsl.select()
+            .from(P_SHIPMENT)
+            .where(P_SHIPMENT.DELIVERY_ID.eq(deliveryId))
+            .orderBy(P_SHIPMENT.SEQUENCE.asc())
+            .fetch();
+    if (records.isEmpty()) throw new DeliveryException.ShipmentNotFoundException();
+    return recordMapper.toShipmentResponseList(records);
+  }
 }

--- a/src/main/java/com/followMe/delivery_server/delivery/infra/query/DeliveryQueryRepository.java
+++ b/src/main/java/com/followMe/delivery_server/delivery/infra/query/DeliveryQueryRepository.java
@@ -8,13 +8,13 @@ import com.followMe.common.pagination.PageResponse;
 import com.followMe.delivery_server.delivery.application.dto.DeliveryListItemDto;
 import com.followMe.delivery_server.delivery.application.dto.DeliveryResponseDto;
 import com.followMe.delivery_server.delivery.application.dto.DeliverySearchCondition;
+import com.followMe.delivery_server.delivery.domain.exception.DeliveryException;
 import com.followMe.delivery_server.delivery.domain.exception.DeliveryException.DeliveryNotFoundException;
 import java.util.List;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.jooq.*;
 import org.jooq.Record;
-import org.jooq.SelectOrderByStep;
 import org.springframework.stereotype.Repository;
 
 @Repository
@@ -98,5 +98,11 @@ public class DeliveryQueryRepository {
             .fetch();
     if (records.isEmpty()) throw new DeliveryException.ShipmentNotFoundException();
     return recordMapper.toShipmentResponseList(records);
+  }
+
+  public DeliveryResponseDto.ShipmentResponse findShipmentById(UUID shipmentId) {
+    Record record = dsl.select().from(P_SHIPMENT).where(P_SHIPMENT.ID.eq(shipmentId)).fetchOne();
+    if (record == null) throw new DeliveryException.ShipmentNotFoundException();
+    return recordMapper.toShipmentResponse(record);
   }
 }

--- a/src/main/java/com/followMe/delivery_server/delivery/infra/query/DeliveryRecordMapper.java
+++ b/src/main/java/com/followMe/delivery_server/delivery/infra/query/DeliveryRecordMapper.java
@@ -89,40 +89,45 @@ public class DeliveryRecordMapper {
         first.get(P_DELIVERY.CREATED_AT).toLocalDateTime());
   }
 
-  private NodeResponse fromNodeOf(Record r) {
-    return new NodeResponse(
-        r.get(P_SHIPMENT.FROM_NODE_ID),
-        NodeType.valueOf(r.get(P_SHIPMENT.FROM_NODE_TYPE)),
-        r.get(P_SHIPMENT.FROM_NODE_NAME));
+  public List<ShipmentResponse> toShipmentResponseList(Result<Record> records) {
+    return records.map(this::toShipmentResponse);
   }
 
-  private NodeResponse toNodeOf(Record r) {
-    return new NodeResponse(
-        r.get(P_SHIPMENT.TO_NODE_ID),
-        NodeType.valueOf(r.get(P_SHIPMENT.TO_NODE_TYPE)),
-        r.get(P_SHIPMENT.TO_NODE_NAME));
-  }
-
-  private ShipmentResponse toShipmentResponse(Record r) {
+  protected ShipmentResponse toShipmentResponse(Record record) {
     return new ShipmentResponse(
-        r.get(P_SHIPMENT.ID),
-        r.get(P_SHIPMENT.SEQUENCE),
-        ShipmentStatus.valueOf(r.get(P_SHIPMENT.STATUS)),
-        ShipmentType.valueOf(r.get(P_SHIPMENT.TYPE)),
-        fromNodeOf(r),
-        toNodeOf(r),
-        r.get(P_SHIPMENT.DELIVERY_MANAGER_ID) != null
+        record.get(P_SHIPMENT.ID),
+        record.get(P_SHIPMENT.SEQUENCE),
+        ShipmentStatus.valueOf(record.get(P_SHIPMENT.STATUS)),
+        ShipmentType.valueOf(record.get(P_SHIPMENT.TYPE)),
+        fromNodeOf(record),
+        toNodeOf(record),
+        record.get(P_SHIPMENT.DELIVERY_MANAGER_ID) != null
             ? new DeliveryManagerResponse(
-                r.get(P_SHIPMENT.DELIVERY_MANAGER_ID), r.get(P_SHIPMENT.DELIVERY_MANAGER_NAME))
+                record.get(P_SHIPMENT.DELIVERY_MANAGER_ID),
+                record.get(P_SHIPMENT.DELIVERY_MANAGER_NAME))
             : null,
-        r.get(P_SHIPMENT.SHIPPED_AT) != null
-            ? r.get(P_SHIPMENT.SHIPPED_AT).toLocalDateTime()
+        record.get(P_SHIPMENT.SHIPPED_AT) != null
+            ? record.get(P_SHIPMENT.SHIPPED_AT).toLocalDateTime()
             : null,
-        r.get(P_SHIPMENT.ARRIVED_AT) != null
-            ? r.get(P_SHIPMENT.ARRIVED_AT).toLocalDateTime()
+        record.get(P_SHIPMENT.ARRIVED_AT) != null
+            ? record.get(P_SHIPMENT.ARRIVED_AT).toLocalDateTime()
             : null,
-        r.get(P_SHIPMENT.COMPLETED_AT) != null
-            ? r.get(P_SHIPMENT.COMPLETED_AT).toLocalDateTime()
+        record.get(P_SHIPMENT.COMPLETED_AT) != null
+            ? record.get(P_SHIPMENT.COMPLETED_AT).toLocalDateTime()
             : null);
+  }
+
+  private NodeResponse fromNodeOf(Record record) {
+    return new NodeResponse(
+        record.get(P_SHIPMENT.FROM_NODE_ID),
+        NodeType.valueOf(record.get(P_SHIPMENT.FROM_NODE_TYPE)),
+        record.get(P_SHIPMENT.FROM_NODE_NAME));
+  }
+
+  private NodeResponse toNodeOf(Record record) {
+    return new NodeResponse(
+        record.get(P_SHIPMENT.TO_NODE_ID),
+        NodeType.valueOf(record.get(P_SHIPMENT.TO_NODE_TYPE)),
+        record.get(P_SHIPMENT.TO_NODE_NAME));
   }
 }

--- a/src/main/java/com/followMe/delivery_server/delivery/infra/query/DeliveryRecordMapper.java
+++ b/src/main/java/com/followMe/delivery_server/delivery/infra/query/DeliveryRecordMapper.java
@@ -28,7 +28,7 @@ public class DeliveryRecordMapper {
     return new DeliveryResponseDto(
         first.get(P_DELIVERY.ID),
         first.get(P_DELIVERY.ORDER_ID),
-        DeliveryStatus.valueOf(first.get(P_DELIVERY.STATUS)),
+        deriveDeliveryStatus(shipments.stream().map(ShipmentResponse::status).toList()),
         shipments,
         first.get(P_DELIVERY.CREATED_AT).toLocalDateTime());
   }
@@ -40,7 +40,7 @@ public class DeliveryRecordMapper {
       return new DeliveryListItemDto(
           first.get(P_DELIVERY.ID),
           first.get(P_DELIVERY.ORDER_ID),
-          DeliveryStatus.valueOf(first.get(P_DELIVERY.STATUS)),
+          DeliveryStatus.READY,
           null,
           null,
           0,
@@ -76,10 +76,13 @@ public class DeliveryRecordMapper {
       }
     }
 
+    List<ShipmentStatus> statuses =
+        shipments.stream().map(r -> ShipmentStatus.valueOf(r.get(P_SHIPMENT.STATUS))).toList();
+
     return new DeliveryListItemDto(
         first.get(P_DELIVERY.ID),
         first.get(P_DELIVERY.ORDER_ID),
-        DeliveryStatus.valueOf(first.get(P_DELIVERY.STATUS)),
+        deriveDeliveryStatus(statuses),
         fromHub,
         toVendor,
         totalShipments,
@@ -115,6 +118,17 @@ public class DeliveryRecordMapper {
         record.get(P_SHIPMENT.COMPLETED_AT) != null
             ? record.get(P_SHIPMENT.COMPLETED_AT).toLocalDateTime()
             : null);
+  }
+
+  private DeliveryStatus deriveDeliveryStatus(List<ShipmentStatus> statuses) {
+    if (statuses.isEmpty()) return DeliveryStatus.READY;
+    if (statuses.stream().anyMatch(s -> s == ShipmentStatus.FAILED)) return DeliveryStatus.FAILED;
+    if (statuses.stream().allMatch(s -> s == ShipmentStatus.COMPLETED))
+      return DeliveryStatus.COMPLETED;
+    if (statuses.stream().anyMatch(ShipmentStatus::isInProgress)) return DeliveryStatus.IN_PROGRESS;
+    if (statuses.stream().allMatch(s -> s == ShipmentStatus.CANCELLED))
+      return DeliveryStatus.CANCELLED;
+    return DeliveryStatus.READY;
   }
 
   private NodeResponse fromNodeOf(Record record) {

--- a/src/main/java/com/followMe/delivery_server/delivery/presentation/DeliveryController.java
+++ b/src/main/java/com/followMe/delivery_server/delivery/presentation/DeliveryController.java
@@ -4,12 +4,14 @@ import com.followMe.common.pagination.PageRequest;
 import com.followMe.common.pagination.PageResponse;
 import com.followMe.common.response.ApiResponse;
 import com.followMe.delivery_server.delivery.application.DeliveryService;
+import com.followMe.delivery_server.delivery.application.ShipmentService;
 import com.followMe.delivery_server.delivery.application.UserContext;
 import com.followMe.delivery_server.delivery.application.UserRole;
 import com.followMe.delivery_server.delivery.application.dto.DeliveryListItemDto;
 import com.followMe.delivery_server.delivery.application.dto.DeliveryResponseDto;
 import com.followMe.delivery_server.delivery.application.dto.DeliverySearchCondition;
 import com.followMe.delivery_server.delivery.application.dto.OrderCreateCommand;
+import java.util.List;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -21,6 +23,7 @@ import org.springframework.web.bind.annotation.*;
 public class DeliveryController {
 
   private final DeliveryService deliveryService;
+  private final ShipmentService shipmentService;
 
   @ModelAttribute
   public UserContext userContext(
@@ -74,5 +77,13 @@ public class DeliveryController {
       @PathVariable UUID deliveryId, @ModelAttribute UserContext user) {
     deliveryService.deleteDelivery(user, deliveryId);
     return ApiResponse.ok();
+  }
+
+  @GetMapping("/{deliveryId}/shipments")
+  public ResponseEntity<ApiResponse> getShipmentsByDeliveryId(
+      @PathVariable UUID deliveryId, @ModelAttribute UserContext user) {
+    List<DeliveryResponseDto.ShipmentResponse> response =
+        shipmentService.getShipmentsByDeliveryId(user, deliveryId);
+    return ApiResponse.ok(response);
   }
 }

--- a/src/main/java/com/followMe/delivery_server/delivery/presentation/ShipmentController.java
+++ b/src/main/java/com/followMe/delivery_server/delivery/presentation/ShipmentController.java
@@ -6,6 +6,7 @@ import com.followMe.delivery_server.delivery.application.UserContext;
 import com.followMe.delivery_server.delivery.application.UserRole;
 import com.followMe.delivery_server.delivery.application.dto.DeliveryResponseDto;
 import com.followMe.delivery_server.delivery.application.dto.ShipmentStatusUpdateRequest;
+import jakarta.validation.Valid;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -38,7 +39,7 @@ public class ShipmentController {
   public ResponseEntity<ApiResponse> updateStatus(
       @PathVariable UUID shipmentId,
       @ModelAttribute UserContext user,
-      @RequestBody ShipmentStatusUpdateRequest statusRequest) {
+      @RequestBody @Valid ShipmentStatusUpdateRequest statusRequest) {
     shipmentService.updateStatus(user, shipmentId, statusRequest.status());
     return ApiResponse.ok();
   }

--- a/src/main/java/com/followMe/delivery_server/delivery/presentation/ShipmentController.java
+++ b/src/main/java/com/followMe/delivery_server/delivery/presentation/ShipmentController.java
@@ -1,0 +1,45 @@
+package com.followMe.delivery_server.delivery.presentation;
+
+import com.followMe.common.response.ApiResponse;
+import com.followMe.delivery_server.delivery.application.ShipmentService;
+import com.followMe.delivery_server.delivery.application.UserContext;
+import com.followMe.delivery_server.delivery.application.UserRole;
+import com.followMe.delivery_server.delivery.application.dto.DeliveryResponseDto;
+import com.followMe.delivery_server.delivery.application.dto.ShipmentStatusUpdateRequest;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/api/v1/shipments")
+@RequiredArgsConstructor
+public class ShipmentController {
+
+  private final ShipmentService shipmentService;
+
+  @ModelAttribute
+  public UserContext userContext(
+      @RequestHeader("X-User-Id") UUID userId,
+      @RequestHeader("X-User-Role") UserRole role,
+      @RequestHeader(value = "X-Hub-Id", required = false) UUID hubId,
+      @RequestHeader(value = "X-Vendor-Id", required = false) UUID vendorId) {
+    return new UserContext(userId, role, hubId, vendorId);
+  }
+
+  @GetMapping("/{shipmentId}")
+  public ResponseEntity<ApiResponse> getShipment(
+      @PathVariable UUID shipmentId, @ModelAttribute UserContext user) {
+    DeliveryResponseDto.ShipmentResponse response = shipmentService.getShipment(user, shipmentId);
+    return ApiResponse.ok(response);
+  }
+
+  @PatchMapping("/{shipmentId}/status")
+  public ResponseEntity<ApiResponse> updateStatus(
+      @PathVariable UUID shipmentId,
+      @ModelAttribute UserContext user,
+      @RequestBody ShipmentStatusUpdateRequest statusRequest) {
+    shipmentService.updateStatus(user, shipmentId, statusRequest.status());
+    return ApiResponse.ok();
+  }
+}


### PR DESCRIPTION
### 📌 관련 이슈
- close #8 

### 💡 작업 내용
- 배송 구간(Shipment) 목록 조회 API 추가
- 배송 구간 단건 조회 API 추가
- 배송 구간 상태 변경 API 추가                             
- HTTP 테스트 파일 추가                                                           
                                                                                                            
### 🔍 변경 이유                                                                                          
- 배송 담당자가 자신이 맡은 구간의 상태를 순차적으로 업데이트할 수 있어야 함                              
- 마지막 구간(HUB_TO_VENDOR) 완료 시 배송(Delivery) 상태도 자동으로 COMPLETED로 전환                      
- 어느 구간이든 실패 시 배송 전체가 FAILED로 전환                                                         
                                                                                                            
### 📝 리뷰 포인트                                                                                        
- 상태 전환 시 이전 구간 완료 여부 순서 체크 + Delivery 상태 연동     
  로직이 함께 있음. Shipment가 Delivery를 직접 변경하는 구조가 적절한지 확인 부탁드립니다.                  
 - MASTER / DELIVERY_MANAGER(본인 배정 구간)만 허용. 권한 범위가 맞는지 확인 부탁드립니다. 

        
  ### 🧠 기타 참고 사항                                                                                     
  - 낙관적 락(`@Version`)은 `Shipment`에만 적용. `@Lock(OPTIMISTIC)` 어노테이션은 `Delivery`에 `@Version`이 
  없어 에러 발생으로 제거함 — `@Version`만으로 커밋 시점 충돌 감지가 동작함                                 
  - 구간 순서 체크는 `ship()` 호출 시점에만 수행 (이후 전환은 해당 구간 자체의 진행이므로 불필요)
